### PR TITLE
Implement SqlGenerator and add initial Vitest suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "beiju",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/src/codegen/SqlGenerator.test.ts
+++ b/src/codegen/SqlGenerator.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import { columnRef } from '../domain/model/ColumnRef.js'
+import { SqlGenerator } from './SqlGenerator.js'
+
+describe('SqlGenerator', () => {
+  it('gera SELECT simples com WHERE', () => {
+    const query = {
+      from: { table: 'orders', alias: 'o' },
+      select: [columnRef('seller_name', 'string', 'o')],
+      where: {
+        conditions: [{ column: columnRef('month', 'string', 'o'), op: '=', value: '2026-01' }],
+        operator: 'AND' as const,
+      },
+    }
+
+    const compiled = SqlGenerator.compile(query)
+
+    expect(compiled).toEqual({
+      sql: 'SELECT o.seller_name FROM orders AS o WHERE o.month = $1',
+      params: ['2026-01'],
+    })
+  })
+
+  it('gera SELECT com GROUP BY e agregação', () => {
+    const query = {
+      from: { table: 'orders' },
+      select: [
+        columnRef('seller_name', 'string'),
+        {
+          kind: 'AggregateExpr' as const,
+          fn: 'SUM' as const,
+          column: columnRef('total_amount', 'number'),
+          alias: 'total_sales',
+        },
+      ],
+      groupBy: [columnRef('seller_name', 'string')],
+    }
+
+    const compiled = SqlGenerator.compile(query)
+
+    expect(compiled).toEqual({
+      sql: 'SELECT seller_name, SUM(total_amount) AS total_sales FROM orders GROUP BY seller_name',
+      params: [],
+    })
+  })
+
+  it('gera SELECT com Window Function RANK e LAG', () => {
+    const query = {
+      from: { table: 'orders', alias: 'o' },
+      select: [
+        {
+          kind: 'WindowFunctionExpr' as const,
+          fn: 'RANK' as const,
+          window: {
+            kind: 'WindowSpec' as const,
+            orderBy: [
+              {
+                kind: 'OrderByItem' as const,
+                column: columnRef('total_amount', 'number', 'o'),
+                direction: 'DESC' as const,
+              },
+            ],
+          },
+          alias: 'ranking',
+        },
+        {
+          kind: 'WindowFunctionExpr' as const,
+          fn: 'LAG' as const,
+          column: columnRef('total_amount', 'number', 'o'),
+          offset: 1,
+          window: {
+            kind: 'WindowSpec' as const,
+            orderBy: [
+              {
+                kind: 'OrderByItem' as const,
+                column: columnRef('month', 'string', 'o'),
+                direction: 'ASC' as const,
+              },
+            ],
+          },
+          alias: 'prev_month',
+        },
+      ],
+    }
+
+    const compiled = SqlGenerator.compile(query)
+
+    expect(compiled).toEqual({
+      sql: 'SELECT RANK() OVER (ORDER BY o.total_amount DESC) AS ranking, LAG(o.total_amount, 1) OVER (ORDER BY o.month ASC) AS prev_month FROM orders AS o',
+      params: [],
+    })
+  })
+
+  it('gera OVER com PARTITION BY e ORDER BY', () => {
+    const query = {
+      from: { table: 'orders', alias: 'o' },
+      select: [
+        {
+          kind: 'WindowFunctionExpr' as const,
+          fn: 'ROW_NUMBER' as const,
+          window: {
+            kind: 'WindowSpec' as const,
+            partitionBy: [columnRef('seller_name', 'string', 'o')],
+            orderBy: [
+              {
+                kind: 'OrderByItem' as const,
+                column: columnRef('total_amount', 'number', 'o'),
+                direction: 'DESC' as const,
+              },
+            ],
+          },
+          alias: 'row_num',
+        },
+      ],
+    }
+
+    const compiled = SqlGenerator.compile(query)
+
+    expect(compiled).toEqual({
+      sql: 'SELECT ROW_NUMBER() OVER (PARTITION BY o.seller_name ORDER BY o.total_amount DESC) AS row_num FROM orders AS o',
+      params: [],
+    })
+  })
+})

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -1,0 +1,182 @@
+import type { AggregateExpr, WindowFunctionExpr } from '../domain/model/AggregateExpr.js'
+import type { ColumnRef } from '../domain/model/ColumnRef.js'
+import type { FrameBoundary, FrameSpec, OrderByItem, WindowSpec } from '../domain/model/WindowSpec.js'
+import type {
+  SelectQuery,
+  SelectionItem,
+  WhereClause,
+  WhereCondition,
+} from '../domain/ports/SelectQuery.js'
+
+export interface SqlCompileResult {
+  readonly sql: string
+  readonly params: unknown[]
+}
+
+export class SqlGenerator {
+  static compile(query: SelectQuery): SqlCompileResult {
+    const params: unknown[] = []
+
+    const selectSql = query.select.map((item) => SqlGenerator.compileSelection(item)).join(', ')
+
+    const fromSql = query.from.alias
+      ? `${query.from.table} AS ${query.from.alias}`
+      : query.from.table
+
+    const clauses: string[] = [`SELECT ${selectSql}`, `FROM ${fromSql}`]
+
+    if (query.where) {
+      clauses.push(`WHERE ${SqlGenerator.compileWhere(query.where, params)}`)
+    }
+
+    if (query.groupBy?.length) {
+      clauses.push(`GROUP BY ${query.groupBy.map((column) => SqlGenerator.compileColumn(column)).join(', ')}`)
+    }
+
+    if (query.orderBy?.length) {
+      clauses.push(
+        `ORDER BY ${query.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(', ')}`
+      )
+    }
+
+    if (typeof query.limit === 'number') {
+      clauses.push(`LIMIT ${query.limit}`)
+    }
+
+    if (typeof query.offset === 'number') {
+      clauses.push(`OFFSET ${query.offset}`)
+    }
+
+    return {
+      sql: clauses.join(' '),
+      params,
+    }
+  }
+
+  private static compileSelection(item: SelectionItem): string {
+    if (item.kind === 'ColumnRef') {
+      return SqlGenerator.compileColumn(item)
+    }
+
+    if (item.kind === 'AggregateExpr') {
+      return SqlGenerator.compileAggregate(item)
+    }
+
+    return SqlGenerator.compileWindowFn(item)
+  }
+
+  private static compileColumn(column: ColumnRef): string {
+    return column.table ? `${column.table}.${column.column}` : column.column
+  }
+
+  private static compileAggregate(aggregate: AggregateExpr): string {
+    const expr = `${aggregate.fn}(${SqlGenerator.compileColumn(aggregate.column)})`
+    const withWindow = aggregate.window ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}` : expr
+
+    return aggregate.alias ? `${withWindow} AS ${aggregate.alias}` : withWindow
+  }
+
+  private static compileWindowFn(windowFn: WindowFunctionExpr): string {
+    const args: unknown[] = []
+
+    if (windowFn.column) {
+      args.push(SqlGenerator.compileColumn(windowFn.column))
+    }
+
+    if (typeof windowFn.offset === 'number') {
+      args.push(windowFn.offset)
+    }
+
+    const fnExpr = `${windowFn.fn}(${args.join(', ')})`
+    const withWindow = `${fnExpr} ${SqlGenerator.compileWindow(windowFn.window)}`
+
+    return windowFn.alias ? `${withWindow} AS ${windowFn.alias}` : withWindow
+  }
+
+  private static compileWindow(window: WindowSpec): string {
+    const parts: string[] = []
+
+    if (window.partitionBy?.length) {
+      parts.push(`PARTITION BY ${window.partitionBy.map((column) => SqlGenerator.compileColumn(column)).join(', ')}`)
+    }
+
+    if (window.orderBy?.length) {
+      parts.push(`ORDER BY ${window.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(', ')}`)
+    }
+
+    if (window.frame) {
+      parts.push(SqlGenerator.compileFrame(window.frame))
+    }
+
+    return `OVER (${parts.join(' ')})`
+  }
+
+  private static compileFrame(frame: FrameSpec): string {
+    const start = SqlGenerator.compileFrameBoundary(frame.start)
+    const end = SqlGenerator.compileFrameBoundary(frame.end)
+
+    return `${frame.type} BETWEEN ${start} AND ${end}`
+  }
+
+  private static compileFrameBoundary(boundary: FrameBoundary): string {
+    if (boundary === 'unbounded') {
+      return 'UNBOUNDED PRECEDING'
+    }
+
+    if (boundary === 'current') {
+      return 'CURRENT ROW'
+    }
+
+    if (boundary < 0) {
+      return `${Math.abs(boundary)} PRECEDING`
+    }
+
+    if (boundary > 0) {
+      return `${boundary} FOLLOWING`
+    }
+
+    return 'CURRENT ROW'
+  }
+
+  private static compileWhere(where: WhereClause, params: unknown[]): string {
+    return where.conditions
+      .map((condition) => SqlGenerator.compileCondition(condition, params))
+      .join(` ${where.operator} `)
+  }
+
+  private static compileCondition(condition: WhereCondition, params: unknown[]): string {
+    const columnSql = SqlGenerator.compileColumn(condition.column)
+
+    if (condition.op === 'IN') {
+      if (!Array.isArray(condition.value) || condition.value.length === 0) {
+        throw new Error('IN operator requires a non-empty array value')
+      }
+
+      const placeholders = condition.value.map((value) => SqlGenerator.pushParam(params, value)).join(', ')
+      return `${columnSql} IN (${placeholders})`
+    }
+
+    if (condition.op === 'BETWEEN') {
+      if (!Array.isArray(condition.value) || condition.value.length !== 2) {
+        throw new Error('BETWEEN operator requires an array with exactly two values')
+      }
+
+      const start = SqlGenerator.pushParam(params, condition.value[0])
+      const end = SqlGenerator.pushParam(params, condition.value[1])
+
+      return `${columnSql} BETWEEN ${start} AND ${end}`
+    }
+
+    const valuePlaceholder = SqlGenerator.pushParam(params, condition.value)
+    return `${columnSql} ${condition.op} ${valuePlaceholder}`
+  }
+
+  private static compileOrderByItem(item: { column: ColumnRef; direction: 'ASC' | 'DESC' } | OrderByItem): string {
+    return `${SqlGenerator.compileColumn(item.column)} ${item.direction}`
+  }
+
+  private static pushParam(params: unknown[], value: unknown): string {
+    params.push(value)
+    return `$${params.length}`
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation
- Provide a pure AST-to-SQL compiler that converts `SelectQuery` nodes into parameterized SQL and parameters via `SqlGenerator.compile`.
- Add first-class support for analytical constructs (aggregates, window functions and `OVER` clauses) so downstream builders can produce complex OLAP queries without embedding SQL strings.
- Seed the project with TDD coverage for the generator so subsequent builder and adapter work can be driven by tests.

### Description
- Implemented `SqlGenerator` in `src/codegen/SqlGenerator.ts` with `compile` and helper methods for selections, columns, aggregates, window functions, frames and parameter handling.
- Added runtime validation for `IN` and `BETWEEN` operators and generation of parameter placeholders (`$1`, `$2`, ...) via an internal `pushParam` helper.
- Added test suite `src/codegen/SqlGenerator.test.ts` covering four scenarios: simple `WHERE`, `GROUP BY` + aggregation, window functions (`RANK`/`LAG`) and `OVER` with `PARTITION BY` + `ORDER BY`.
- Bootstrapped minimal TypeScript and test configuration files (`package.json` with `test` script and devDependencies, and `tsconfig.json`).

### Testing
- Attempted to install dependencies with `npm install`, but the install failed due to registry `403 Forbidden` errors in this environment.
- Attempted to run the test runner with `npm test`, but it failed because `vitest` is not installed in the environment and could not be fetched.
- The `vitest` test file `src/codegen/SqlGenerator.test.ts` is present and is expected to pass locally once `devDependencies` are installed and `vitest` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc67b7f58483278a6e7f0691ac0768)