### PR TITLE
refactor: Adiciona types em pasta segmentada

### DIFF
--- a/src/application/ColumnContext.ts
+++ b/src/application/ColumnContext.ts
@@ -1,11 +1,10 @@
-// application/builders/ColumnContext.ts
-import { ColumnRef, SqlType } from '../domain/model/ColumnRef.js'
-import { AggFn } from '../domain/model/expr/AggregateExpr.js'
+import { ColumnRef } from '../domain/model/ColumnRef.js'
+import { SqlType } from '../domain/types/SqlType.js'
+import { AggFnType } from '../domain/types/AggFnType.js'
 import { AggExprBuilder } from './builders/AggExprBuilder.js'
 import { WindowFnExprBuilder } from './builders/WindowFnExprBuilder.js'
 
 export class ColumnContext {
-  // --- Referência simples ---
 
   col(name: string, table?: string): ColumnRef {
     return new ColumnRef(name, 'string', table)
@@ -13,7 +12,7 @@ export class ColumnContext {
 
   // --- Agregações ---
 
-  private agg(fn: AggFn, column: string, type: SqlType = 'number'): AggExprBuilder {
+  private agg(fn: AggFnType, column: string, type: SqlType = 'number'): AggExprBuilder {
     return new AggExprBuilder(fn, new ColumnRef(column, type))
   }
 

--- a/src/application/builders/AggExprBuilder.ts
+++ b/src/application/builders/AggExprBuilder.ts
@@ -1,5 +1,6 @@
 import { WindowSpec } from "../../domain/model/WindowSpec.js"
-import { AggFn, AggregateExpr } from "../../domain/model/expr/AggregateExpr.js"
+import { AggregateExpr } from "../../domain/model/expr/AggregateExpr.js"
+import { AggFnType } from "../../domain/types/AggFnType.js"
 import { ColumnRef } from "../../domain/model/ColumnRef.js"
 import { WindowBuilderFn, WindowBuilder } from "./WindowBuilder.js"
 
@@ -8,7 +9,7 @@ export class AggExprBuilder {
   private windowSpec?: WindowSpec
 
   constructor(
-    private readonly fn: AggFn,
+    private readonly fn: AggFnType,
     private readonly column: ColumnRef,
   ) {}
 

--- a/src/application/builders/SelectBuilder.ts
+++ b/src/application/builders/SelectBuilder.ts
@@ -1,5 +1,5 @@
-// application/builders/SelectBuilder.ts
 import type { IQueryExecutor } from '../../domain/interfaces/IQueryExecutor.js'
+import { SelectionItemType } from '../../domain/types/SelectionItemType.js'
 import { ColumnRef } from '../../domain/model/ColumnRef.js'
 import { SelectQuery } from '../../domain/model/clause/SelectQuery.js'
 import { WhereClause } from '../../domain/model/clause/WhereClause.js'
@@ -17,7 +17,7 @@ export type WhereFn  = (c: WhereContext) => WhereCondition | WhereCondition[] | 
 
 export class SelectBuilder implements ISelectBuilder {
   private fromClause?: { table: string; alias?: string }
-  private selections: ReturnType<SelectQuery['select']['values']> extends ArrayIterator<infer T> ? T[] : any[] = [];
+  private selections: SelectionItemType[] = [];
   private whereClause?: WhereClause
   private groupByColumns: ColumnRef[] = []
   private orderByItems: OrderByItem[] = []

--- a/src/application/builders/WindowFnExprBuilder.ts
+++ b/src/application/builders/WindowFnExprBuilder.ts
@@ -1,5 +1,6 @@
-import { ColumnRef, SqlType } from '../../domain/model/ColumnRef.js'
-import { WindowFunctionExpr, WindowFn } from '../../domain/model/expr/WindowFunctionExpr.js'
+import { ColumnRef } from '../../domain/model/ColumnRef.js'
+import { WindowFunctionExpr } from '../../domain/model/expr/WindowFunctionExpr.js'
+import { WindowFnType } from '../../domain/types/WindowFnType.js'
 import { WindowSpec } from '../../domain/model/WindowSpec.js'
 import { WindowBuilder } from './WindowBuilder.js'
 import { WindowBuilderFn } from './WindowBuilder.js'
@@ -9,7 +10,7 @@ export class WindowFnExprBuilder {
   private windowSpec?: WindowSpec
 
   constructor(
-    private readonly fn: WindowFn,
+    private readonly fn: WindowFnType,
     private readonly column?: ColumnRef,
     private readonly offset?: number,
   ) {}

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -5,7 +5,7 @@ import type { WindowSpec } from '../domain/model/WindowSpec.js'
 import type { OrderByItem} from '../domain/model/OrderByItem.js'
 import type { FrameBoundary, FrameSpec } from '../domain/model/FrameSpec.js'
 import type { SelectQuery } from '../domain/model/clause/SelectQuery.js'
-import { SelectionItem } from '../domain/interfaces/ISelectionItem.js'
+import { SelectionItemType } from '../domain/types/SelectionItemType.js'
 import type { WhereClause } from '../domain/model/clause/WhereClause.js'
 import { WhereCondition } from '../domain/model/clause/WhereCondition.js'
 import { ISqlCompileResult } from '../domain/interfaces/ISqlCompileResult.js'
@@ -50,7 +50,7 @@ export class SqlGenerator {
     }
   }
 
-  private static compileSelection(item: SelectionItem): string {
+  private static compileSelection(item: SelectionItemType): string {
     if (item.kind === 'ColumnRef') {
       return SqlGenerator.compileColumn(item)
     }

--- a/src/domain/interfaces/IBuilder.ts
+++ b/src/domain/interfaces/IBuilder.ts
@@ -1,8 +1,6 @@
-// domain/interfaces/IBuilder.ts
-
 /**
  * Contrato base para todos os builders do Beiju.
- * @template T — tipo produzido pelo build()
+ * @template T
  */
 export interface IBuilder<T> {
   build(): T

--- a/src/domain/interfaces/IQueryExecutor.ts
+++ b/src/domain/interfaces/IQueryExecutor.ts
@@ -1,9 +1,9 @@
-export interface QueryResult<T> {
+export interface IQueryResult<T> {
   readonly rows: T[]
   readonly rowCount: number
 }
 
 export interface IQueryExecutor {
-  execute<T>(sql: string, params: unknown[]): Promise<QueryResult<T>>
+  execute<T>(sql: string, params: unknown[]): Promise<IQueryResult<T>>
   close(): Promise<void>
 }

--- a/src/domain/interfaces/IQueryNode.ts
+++ b/src/domain/interfaces/IQueryNode.ts
@@ -1,13 +1,5 @@
-export type QueryNodeKind =
-  | 'SelectQuery'
-  | 'ColumnRef'
-  | 'AggregateExpr'
-  | 'WindowSpec'
-  | 'WindowFunctionExpr'
-  | 'WhereClause'
-  | 'OrderByItem'
-  | 'FrameSpec'
+import { QueryNodeKindType } from "../types/QueryNodeKindType.js"
 
 export interface IQueryNode {
-  readonly kind: QueryNodeKind
+  readonly kind: QueryNodeKindType
 }

--- a/src/domain/model/ColumnRef.ts
+++ b/src/domain/model/ColumnRef.ts
@@ -1,4 +1,4 @@
-export type SqlType = 'number' | 'string' | 'date' | 'boolean'
+import { SqlType } from "../types/SqlType.js"
 
 export class ColumnRef<T extends SqlType = SqlType> {
   readonly kind = 'ColumnRef' as const

--- a/src/domain/model/clause/SelectQuery.ts
+++ b/src/domain/model/clause/SelectQuery.ts
@@ -2,12 +2,12 @@
 import { ColumnRef } from '../ColumnRef.js'
 import { WhereClause } from './WhereClause.js'
 import { OrderByItem } from '../OrderByItem.js' 
-import { SelectionItem } from '../../interfaces/ISelectionItem.js';
+import { SelectionItemType } from '../../types/SelectionItemType.js';
 
 export class SelectQuery {
   constructor(
     readonly from: { table: string; alias?: string },
-    readonly select: SelectionItem[],
+    readonly select: SelectionItemType[],
     readonly where?: WhereClause,
     readonly groupBy?: ColumnRef[],
     readonly orderBy?: OrderByItem[],

--- a/src/domain/model/clause/WhereCondition.ts
+++ b/src/domain/model/clause/WhereCondition.ts
@@ -1,10 +1,10 @@
 import { ColumnRef } from "../ColumnRef.js";
-export type WhereOp = '=' | '!=' | '<>' | '>' | '<' | '>=' | '<=' | 'BETWEEN' | 'IN' 
+import { WhereOpType } from "../../types/WhereOpType.js";
 
 export class WhereCondition {
   constructor(
     readonly column: ColumnRef,
-    readonly op: WhereOp,
+    readonly op: WhereOpType,
     readonly value: unknown,
   ) {}
 }

--- a/src/domain/model/expr/AggregateExpr.ts
+++ b/src/domain/model/expr/AggregateExpr.ts
@@ -1,14 +1,14 @@
 // domain/model/AggregateExpr.ts
-import { ColumnRef, SqlType } from '../ColumnRef.js'
+import { ColumnRef } from '../ColumnRef.js'
+import { SqlType } from '../../types/SqlType.js'
 import { WindowSpec } from '../WindowSpec.js'
-
-export type AggFn = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX'
+import { AggFnType } from '../../types/AggFnType.js'
 
 export class AggregateExpr<T extends SqlType = SqlType> {
   readonly kind = 'AggregateExpr' as const
 
   constructor(
-    readonly fn: AggFn,
+    readonly fn: AggFnType,
     readonly column: ColumnRef<T>,
     readonly alias?: string,
     readonly window?: WindowSpec,

--- a/src/domain/model/expr/WindowFunctionExpr.ts
+++ b/src/domain/model/expr/WindowFunctionExpr.ts
@@ -1,13 +1,13 @@
-import { ColumnRef, SqlType } from '../ColumnRef.js'
+import { ColumnRef} from '../ColumnRef.js'
+import { SqlType } from '../../types/SqlType.js'
 import { WindowSpec } from '../WindowSpec.js'
-
-export type WindowFn = 'ROW_NUMBER' | 'RANK' | 'DENSE_RANK' | 'LAG' | 'LEAD' | 'NTILE'
+import { WindowFnType } from '../../types/WindowFnType.js'
 
 export class WindowFunctionExpr<T extends SqlType = SqlType> {
   readonly kind = 'WindowFunctionExpr' as const
 
   constructor(
-    readonly fn: WindowFn,
+    readonly fn: WindowFnType,
     readonly window: WindowSpec,
     readonly column?: ColumnRef<T>,
     readonly offset?: number,

--- a/src/domain/types/AggFnType.ts
+++ b/src/domain/types/AggFnType.ts
@@ -1,0 +1,2 @@
+
+export type AggFnType = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX'

--- a/src/domain/types/QueryNodeKindType.ts
+++ b/src/domain/types/QueryNodeKindType.ts
@@ -1,0 +1,9 @@
+export type QueryNodeKindType =
+  | 'SelectQuery'
+  | 'ColumnRef'
+  | 'AggregateExpr'
+  | 'WindowSpec'
+  | 'WindowFunctionExpr'
+  | 'WhereClause'
+  | 'OrderByItem'
+  | 'FrameSpec'

--- a/src/domain/types/SelectionItemType.ts
+++ b/src/domain/types/SelectionItemType.ts
@@ -2,4 +2,4 @@ import { ColumnRef } from "../model/ColumnRef.js"
 import { AggregateExpr } from "../model/expr/AggregateExpr.js"
 import { WindowFunctionExpr } from "../model/expr/WindowFunctionExpr.js"
 
-export type SelectionItem = ColumnRef | AggregateExpr | WindowFunctionExpr
+export type SelectionItemType = ColumnRef | AggregateExpr | WindowFunctionExpr

--- a/src/domain/types/SqlType.ts
+++ b/src/domain/types/SqlType.ts
@@ -1,0 +1,1 @@
+export type SqlType = 'number' | 'string' | 'date' | 'boolean'

--- a/src/domain/types/WhereOpType.ts
+++ b/src/domain/types/WhereOpType.ts
@@ -1,0 +1,1 @@
+export type WhereOpType = '=' | '!=' | '<>' | '>' | '<' | '>=' | '<=' | 'BETWEEN' | 'IN' 

--- a/src/domain/types/WindowFnType.ts
+++ b/src/domain/types/WindowFnType.ts
@@ -1,0 +1,1 @@
+export type WindowFnType = 'ROW_NUMBER' | 'RANK' | 'DENSE_RANK' | 'LAG' | 'LEAD' | 'NTILE'


### PR DESCRIPTION
Para fins de segmentação de código e melhor legibilidade, criei a pasta "types" com todos os types usados no projeo. A ideia é que os types sejam facilmente encontrados e referenciados quando for mais conveniente. Um novo type deverá ser criado na pasta types a partir de agora. 