### PR TITLE
feat: cria clausulas joins para o projeto e adapta estrutura em camas…

### DIFF
--- a/src/builders/relational/JoinBuilder.ts
+++ b/src/builders/relational/JoinBuilder.ts
@@ -1,0 +1,55 @@
+import { JoinCondition, JoinSpec, JoinType } from '../../core/ast/JoinSpec.js'
+import type { TypedColumn }    from '../../semantic/TypedColumn.js'
+import type { Table }          from '../../semantic/Table.js'
+
+/**
+ * Builder intermediário para cláusulas JOIN.
+ * Criado por SemanticSelectBuilder.innerJoin() / leftJoin() / rightJoin().
+ *
+ * O callback onComplete devolve o controle ao SemanticSelectBuilder
+ * assim que .on() é chamado — permitindo o encadeamento continuar.
+ *
+ * Exemplo:
+ *   .innerJoin(tableUsuarios).on(vendas.usuario_id, tableUsuarios.id)
+ *   .leftJoin(tableProdutos).on(vendas.produto_id, tableProdutos.id)
+ */
+export class JoinBuilder<TBuilder> {
+  private conditions: JoinCondition[] = []
+  private aliasValue?: string
+
+  constructor(
+    private readonly joinTable:  Table,
+    private readonly onComplete: (spec: JoinSpec) => TBuilder,
+    private readonly joinType?:   JoinType,
+  ) {}
+
+  /**
+   * Define o alias SQL da tabela joined.
+   * Exemplo: .innerJoin(usuarios).as('u').on(vendas.usuario_id, ...)
+   */
+  as(alias: string): this {
+    this.aliasValue = alias
+    return this
+  }
+
+  /**
+   * Define a condição ON e finaliza o JOIN,
+   * devolvendo o builder pai para encadeamento.
+   *
+   * Suporta múltiplas condições:
+   *   .on(vendas.usuario_id, usuarios.id)
+   *   .on(vendas.regiao_id,  usuarios.regiao_id) ← segunda condição AND
+   */
+  on(left: TypedColumn, right: TypedColumn): TBuilder {
+    this.conditions.push(new JoinCondition(left.ref, right.ref))
+    
+    return this.onComplete(
+      new JoinSpec(
+        this.joinTable.tableName,
+        this.conditions,
+        this.joinType,
+        this.aliasValue,
+      )
+    )
+  }
+}

--- a/src/builders/relational/SelectBuilder.ts
+++ b/src/builders/relational/SelectBuilder.ts
@@ -93,6 +93,7 @@ export class SelectBuilder implements ISelectBuilder {
       this.fromClause,
       this.selections,
       this.whereClause,
+      undefined,
       this.groupByColumns.length > 0 ? this.groupByColumns : undefined,
       this.orderByItems.length > 0 ? this.orderByItems : undefined,
       this.limitValue,

--- a/src/builders/semantic/SemanticSelectBuilder.ts
+++ b/src/builders/semantic/SemanticSelectBuilder.ts
@@ -11,7 +11,9 @@ import { WindowFnExprBuilder } from '@builders/relational/WindowFnExprBuilder.js
 import { TypedColumn } from '../../semantic/TypedColumn.js' 
 import { AliasedColumn } from '../../semantic/TypedColumn.js'
 import { Table } from '../../semantic/Table.js' 
-
+import { JoinSpec } from '@core/ast/JoinSpec.js'
+import { JoinBuilder } from '@builders/relational/JoinBuilder.js'
+import { ISemanticSelectBuilder } from '@core/interfaces/ISemanticSelectBuilder.js'
 /**
  * Tipos aceitos no .select() do SemanticSelectBuilder.
  * O dev passa colunas, agregações ou window functions — sem strings.
@@ -54,12 +56,14 @@ export type WhereInput =
  *     .limit(10)
  *     .fetch()
  */
-export class SemanticSelectBuilder {
+export class SemanticSelectBuilder implements ISemanticSelectBuilder {
   private whereInput?: WhereInput
   private groupByColumns: ColumnRef[] = []
   private orderByItems: OrderByItem[] = []
   private limitValue?: number
   private offsetValue?: number
+  private joinSpecs: JoinSpec[] = []
+
 
   constructor(
     private readonly table: Table,
@@ -94,12 +98,28 @@ export class SemanticSelectBuilder {
     return this
   }
 
-  // --- Compilação ---
+  private addJoin(spec: JoinSpec): this {
+  this.joinSpecs.push(spec)
+  return this
+  }
 
-  /**
-   * Resolve os itens do select para os tipos da AST.
-   * AggExprBuilder e WindowFnExprBuilder são "buildados" aqui.
-   */
+  join(table: Table): JoinBuilder<this> {
+  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'JOIN')
+  }
+
+  innerJoin(table: Table): JoinBuilder<this> {
+  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'INNER')
+  }
+
+  leftJoin(table: Table): JoinBuilder<this> {
+  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'LEFT')
+  }
+
+  rightJoin(table: Table): JoinBuilder<this> {
+  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'RIGHT')
+  }
+
+
   private resolveSelections(): SelectQuery['select'] {
     return this.selections.map(item => {
       if (item instanceof AggExprBuilder)     return item.build()
@@ -128,14 +148,12 @@ export class SemanticSelectBuilder {
     return new WhereClause([this.whereInput], 'AND')
   }
 
-  /**
-   * Monta o SelectQuery (AST) com todos os dados acumulados.
-   */
   build(): SelectQuery {
     return new SelectQuery(
       { table: this.table.tableName },
       this.resolveSelections(),
       this.resolveWhere(),
+      this.joinSpecs.length > 0 ? this.joinSpecs : undefined,
       this.groupByColumns.length > 0 ? this.groupByColumns : undefined,
       this.orderByItems.length  > 0 ? this.orderByItems  : undefined,
       this.limitValue,
@@ -143,13 +161,11 @@ export class SemanticSelectBuilder {
     )
   }
 
-  /**
-   * Compila para SQL, executa no adapter e retorna os resultados tipados.
-   */
-  async fetch<T extends Record<string, any> = any>(): Promise<T[]> {
+  // Compila para SQL, executa no adapter e retorna os resultados tipados.
+  async fetch<T>(): Promise<T[]> {
     const query = this.build()
     const { sql, params } = SqlGenerator.compile(query)
-    const result = await this.adapter.execute<T>(sql, params)
+    const result = await this.adapter.execute(sql, params)
     return result.rows
   }
 }

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -9,171 +9,211 @@ import { SelectionItemType } from '../core/types/SelectionItemType.js'
 import type { WhereClause } from '../core/ast/clause/WhereClause.js'
 import { WhereCondition } from '../core/ast/clause/WhereCondition.js' 
 import { ISqlCompileResult } from '../core/interfaces/ISqlCompileResult.js'
+import { JoinSpec } from '@core/ast/JoinSpec.js'
 
 export class SqlGenerator {
-   public static compile(query: SelectQuery): ISqlCompileResult {
-    const params: unknown[] = []
+  public static compile(query: SelectQuery): ISqlCompileResult {
+    const params: unknown[] = [];
 
-    const selectSql = query.select.map((item) => SqlGenerator.compileSelection(item)).join(', ')
+    const selectSql = query.select
+      .map((item) => SqlGenerator.compileSelection(item))
+      .join(", ");
 
     const fromSql = query.from.alias
       ? `${query.from.table} AS ${query.from.alias}`
-      : query.from.table
+      : query.from.table;
 
     const clauses: string[] = [`SELECT ${selectSql}`, `FROM ${fromSql}`]
 
+    if (query.joins?.length) {
+      query.joins.forEach((join) => {
+        clauses.push(SqlGenerator.compileJoin(join));
+      });
+    }
+
     if (query.where) {
-      clauses.push(`WHERE ${SqlGenerator.compileWhere(query.where, params)}`)
+      clauses.push(`WHERE ${SqlGenerator.compileWhere(query.where, params)}`);
     }
 
     if (query.groupBy?.length) {
-      clauses.push(`GROUP BY ${query.groupBy.map((column) => SqlGenerator.compileColumn(column)).join(', ')}`)
+      clauses.push(
+        `GROUP BY ${query.groupBy.map((column) => SqlGenerator.compileColumn(column)).join(", ")}`,
+      );
     }
 
     if (query.orderBy?.length) {
       clauses.push(
-        `ORDER BY ${query.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(', ')}`
-      )
+        `ORDER BY ${query.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(", ")}`,
+      );
     }
 
-    if (typeof query.limit === 'number') {
-      clauses.push(`LIMIT ${query.limit}`)
+    if (typeof query.limit === "number") {
+      clauses.push(`LIMIT ${query.limit}`);
     }
 
-    if (typeof query.offset === 'number') {
-      clauses.push(`OFFSET ${query.offset}`)
+    if (typeof query.offset === "number") {
+      clauses.push(`OFFSET ${query.offset}`);
     }
 
     return {
-      sql: clauses.join(' '),
+      sql: clauses.join(" "),
       params,
-    }
+    };
   }
 
   private static compileSelection(item: SelectionItemType): string {
-    if (item.kind === 'ColumnRef') {
-      return SqlGenerator.compileColumn(item)
+    if (item.kind === "ColumnRef") {
+      return SqlGenerator.compileColumn(item);
     }
 
-    if (item.kind === 'AggregateExpr') {
-      return SqlGenerator.compileAggregate(item)
+    if (item.kind === "AggregateExpr") {
+      return SqlGenerator.compileAggregate(item);
     }
 
-    return SqlGenerator.compileWindowFn(item)
+    return SqlGenerator.compileWindowFn(item);
   }
 
   private static compileColumn(column: ColumnRef): string {
-    return column.table ? `${column.table}.${column.column}` : column.column
+    return column.table ? `${column.table}.${column.column}` : column.column;
   }
 
   private static compileAggregate(aggregate: AggregateExpr): string {
-    const expr = `${aggregate.fn}(${SqlGenerator.compileColumn(aggregate.column)})`
-    const withWindow = aggregate.window ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}` : expr
+    const expr = `${aggregate.fn}(${SqlGenerator.compileColumn(aggregate.column)})`;
+    const withWindow = aggregate.window
+      ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}`
+      : expr;
 
-    return aggregate.alias ? `${withWindow} AS ${aggregate.alias}` : withWindow
+    return aggregate.alias ? `${withWindow} AS ${aggregate.alias}` : withWindow;
   }
 
   private static compileWindowFn(windowFn: WindowFunctionExpr): string {
-    const args: unknown[] = []
+    const args: unknown[] = [];
 
     if (windowFn.column) {
-      args.push(SqlGenerator.compileColumn(windowFn.column))
+      args.push(SqlGenerator.compileColumn(windowFn.column));
     }
 
-    if (typeof windowFn.offset === 'number') {
-      args.push(windowFn.offset)
+    if (typeof windowFn.offset === "number") {
+      args.push(windowFn.offset);
     }
 
-    const fnExpr = `${windowFn.fn}(${args.join(', ')})`
-    const withWindow = `${fnExpr} ${SqlGenerator.compileWindow(windowFn.window)}`
+    const fnExpr = `${windowFn.fn}(${args.join(", ")})`;
+    const withWindow = `${fnExpr} ${SqlGenerator.compileWindow(windowFn.window)}`;
 
-    return windowFn.alias ? `${withWindow} AS ${windowFn.alias}` : withWindow
+    return windowFn.alias ? `${withWindow} AS ${windowFn.alias}` : withWindow;
   }
 
   private static compileWindow(window: WindowSpec): string {
-    const parts: string[] = []
+    const parts: string[] = [];
 
     if (window.partitionBy?.length) {
-      parts.push(`PARTITION BY ${window.partitionBy.map((column) => SqlGenerator.compileColumn(column)).join(', ')}`)
+      parts.push(
+        `PARTITION BY ${window.partitionBy.map((column) => SqlGenerator.compileColumn(column)).join(", ")}`,
+      );
     }
 
     if (window.orderBy?.length) {
-      parts.push(`ORDER BY ${window.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(', ')}`)
+      parts.push(
+        `ORDER BY ${window.orderBy.map((item) => SqlGenerator.compileOrderByItem(item)).join(", ")}`,
+      );
     }
 
     if (window.frame) {
-      parts.push(SqlGenerator.compileFrame(window.frame))
+      parts.push(SqlGenerator.compileFrame(window.frame));
     }
 
-    return `OVER (${parts.join(' ')})`
+    return `OVER (${parts.join(" ")})`;
   }
 
   private static compileFrame(frame: FrameSpec): string {
-    const start = SqlGenerator.compileFrameBoundary(frame.start)
-    const end = SqlGenerator.compileFrameBoundary(frame.end)
+    const start = SqlGenerator.compileFrameBoundary(frame.start);
+    const end = SqlGenerator.compileFrameBoundary(frame.end);
 
-    return `${frame.type} BETWEEN ${start} AND ${end}`
+    return `${frame.type} BETWEEN ${start} AND ${end}`;
   }
 
   private static compileFrameBoundary(boundary: FrameBoundary): string {
-    if (boundary === 'unbounded') {
-      return 'UNBOUNDED PRECEDING'
+    if (boundary === "unbounded") {
+      return "UNBOUNDED PRECEDING";
     }
 
-    if (boundary === 'current') {
-      return 'CURRENT ROW'
+    if (boundary === "current") {
+      return "CURRENT ROW";
     }
 
     if (boundary < 0) {
-      return `${Math.abs(boundary)} PRECEDING`
+      return `${Math.abs(boundary)} PRECEDING`;
     }
 
     if (boundary > 0) {
-      return `${boundary} FOLLOWING`
+      return `${boundary} FOLLOWING`;
     }
 
-    return 'CURRENT ROW'
+    return "CURRENT ROW";
   }
 
   private static compileWhere(where: WhereClause, params: unknown[]): string {
     return where.conditions
       .map((condition) => SqlGenerator.compileCondition(condition, params))
-      .join(` ${where.operator} `)
+      .join(` ${where.operator} `);
   }
 
-  private static compileCondition(condition: WhereCondition, params: unknown[]): string {
-    const columnSql = SqlGenerator.compileColumn(condition.column)
+  private static compileCondition(
+    condition: WhereCondition,
+    params: unknown[],
+  ): string {
+    const columnSql = SqlGenerator.compileColumn(condition.column);
 
-    if (condition.op === 'IN') {
+    if (condition.op === "IN") {
       if (!Array.isArray(condition.value) || condition.value.length === 0) {
-        throw new Error('IN operator requires a non-empty array value')
+        throw new Error("IN operator requires a non-empty array value");
       }
 
-      const placeholders = condition.value.map((value) => SqlGenerator.pushParam(params, value)).join(', ')
-      return `${columnSql} IN (${placeholders})`
+      const placeholders = condition.value
+        .map((value) => SqlGenerator.pushParam(params, value))
+        .join(", ");
+      return `${columnSql} IN (${placeholders})`;
     }
 
-    if (condition.op === 'BETWEEN') {
+    if (condition.op === "BETWEEN") {
       if (!Array.isArray(condition.value) || condition.value.length !== 2) {
-        throw new Error('BETWEEN operator requires an array with exactly two values')
+        throw new Error(
+          "BETWEEN operator requires an array with exactly two values",
+        );
       }
 
-      const start = SqlGenerator.pushParam(params, condition.value[0])
-      const end = SqlGenerator.pushParam(params, condition.value[1])
+      const start = SqlGenerator.pushParam(params, condition.value[0]);
+      const end = SqlGenerator.pushParam(params, condition.value[1]);
 
-      return `${columnSql} BETWEEN ${start} AND ${end}`
+      return `${columnSql} BETWEEN ${start} AND ${end}`;
     }
 
-    const valuePlaceholder = SqlGenerator.pushParam(params, condition.value)
-    return `${columnSql} ${condition.op} ${valuePlaceholder}`
+    const valuePlaceholder = SqlGenerator.pushParam(params, condition.value);
+    return `${columnSql} ${condition.op} ${valuePlaceholder}`;
   }
 
-  private static compileOrderByItem(item: { column: ColumnRef; direction: 'ASC' | 'DESC' } | OrderByItem): string {
-    return `${SqlGenerator.compileColumn(item.column)} ${item.direction}`
+  private static compileOrderByItem(
+    item: { column: ColumnRef; direction: "ASC" | "DESC" } | OrderByItem,
+  ): string {
+    return `${SqlGenerator.compileColumn(item.column)} ${item.direction}`;
   }
 
   private static pushParam(params: unknown[], value: unknown): string {
-    params.push(value)
-    return `$${params.length}`
+    params.push(value);
+    return `$${params.length}`;
+  }
+
+  private static compileJoin(join: JoinSpec): string {
+    const tableRef = join.alias 
+    ? `${join.table} AS ${join.alias}` 
+    : join.table;
+
+    const conditions = join.conditions
+      .map((c) => `${SqlGenerator.compileColumn(c.left)} ${c.op} ${SqlGenerator.compileColumn(c.right)}`)
+      .join(" AND ");
+
+    const returnJoin = join.type ? `${join.type} JOIN ${tableRef} ON ${conditions}` : `JOIN ${tableRef} ON ${conditions}`
+
+    return returnJoin;
   }
 }

--- a/src/core/ast/JoinSpec.ts
+++ b/src/core/ast/JoinSpec.ts
@@ -1,0 +1,26 @@
+import { ColumnRef } from '../ColumnRef.js'
+
+export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'JOIN';
+
+/**
+ * Condição atômica de junção.
+ * Representa: tabela_a.coluna = tabela_b.coluna
+ */
+export class JoinCondition {
+  constructor(
+    readonly left:  ColumnRef,
+    readonly right: ColumnRef,
+    readonly op: '=' = '=',
+  ) {}
+}
+
+export class JoinSpec {
+  readonly kind = 'JoinSpec' as const
+
+  constructor(
+    readonly table: string,
+    readonly conditions: JoinCondition[],
+    readonly type?: JoinType,
+    readonly alias?: string,
+  ) {}
+}

--- a/src/core/ast/clause/SelectQuery.ts
+++ b/src/core/ast/clause/SelectQuery.ts
@@ -3,12 +3,14 @@ import { ColumnRef } from '../../ColumnRef.js';
 import { WhereClause } from './WhereClause.js'
 import { OrderByItem } from '../OrderByItem.js';
 import { SelectionItemType } from '../../types/SelectionItemType.js';
+import { JoinSpec } from '../JoinSpec.js';
 
 export class SelectQuery {
   constructor(
     readonly from: { table: string; alias?: string },
     readonly select: SelectionItemType[],
     readonly where?: WhereClause,
+    readonly joins?:  JoinSpec[], 
     readonly groupBy?: ColumnRef[],
     readonly orderBy?: OrderByItem[],
     readonly limit?: number,

--- a/src/core/interfaces/ISemanticSelectBuilder.ts
+++ b/src/core/interfaces/ISemanticSelectBuilder.ts
@@ -1,0 +1,19 @@
+import { JoinBuilder } from "@builders/relational/JoinBuilder.js"
+import { Table } from "@semantic/Table.js"
+/**
+ * Contrato mínimo do SemanticSelectBuilder.
+ * Usado como tipo de retorno da SelectBuilderFactory em Table.ts
+ * para evitar importação circular de SemanticSelectBuilder.
+ */
+export interface ISemanticSelectBuilder {
+  fetch<T>(): Promise<T[]>
+  where(input: unknown): this
+  groupBy(...columns: unknown[]): this
+  orderBy(column: unknown, direction?: 'ASC' | 'DESC'): this
+  limit(n: number): this
+  offset(n: number): this
+  join(table: Table): JoinBuilder<this>
+  innerJoin(table: Table): JoinBuilder<this>
+  leftJoin(table: Table): JoinBuilder<this>
+  rightJoin(table: Table): JoinBuilder<this>
+}

--- a/src/semantic/AnalyticsContext.ts
+++ b/src/semantic/AnalyticsContext.ts
@@ -2,6 +2,8 @@ import { PgAdapter } from '../infrastructure/adapters/PgAdapter.js'
 import type { IDataSourceAdapter } from '../core/interfaces/IDataSourceAdapter.js' 
 import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.js'
 import { Table } from './Table.js' 
+import { TypedColumn } from './TypedColumn.js'
+import { createTable } from './Table.js'
 /**
  * Ponto de entrada do Beiju.
  * Recebe uma connection string e instancia o adapter correto.
@@ -17,39 +19,17 @@ export class AnalyticsContext {
   constructor(connectionString: string) {
     this.adapter = AnalyticsContext.resolveAdapter(connectionString)
   }
+  async table(name: string): Promise<Table & Record<string, TypedColumn>> {
+    const schema = await this.adapter.introspect(name)
+    
+    return createTable(name, schema, this.adapter)
+  }
 
   private static resolveAdapter(cs: string): IDataSourceAdapter {
     if (cs.startsWith('postgresql://') || cs.startsWith('postgres://')) {
         return PgAdapter.getInstance(cs);
     
     }
-    /*
-    if (cs.startsWith('csv://')) {
-      return new CsvAdapter(cs.replace('csv://', ''))
-    }
-      */
-
-    throw new Error(
-      `AnalyticsContext: protocolo não suportado em "${cs}".\n` +
-      `Protocolos aceitos: postgresql://, csv://, parquet://`
-    )
-  }
-
-  /**
-   * Introspecta o schema da tabela/arquivo e retorna um objeto
-   * cujas propriedades são as colunas — com autocomplete e tipos.
-   */
-  async table(name: string): Promise<Table> {
-    const schema = await this.adapter.introspect(name)
-    
-    // 💡 INVERSÃO DE CONTROLE: Criamos a Table passando as funções que geram os builders.
-    // Assim, a Table ganha o método .select() sem precisar importar a classe SemanticSelectBuilder.
-    return new Table(name, schema, this.adapter, {
-      select: (t, items) => new SemanticSelectBuilder(t, items, t.adapter),
-      
-      // Quando você for implementar o resto, bastará adicionar aqui:
-      // update: (t, data) => new SemanticUpdateBuilder(t, data, t.adapter),
-      // delete: (t, filter) => new SemanticDeleteBuilder(t, filter, t.adapter)
-    })
+    throw new Error(`AnalyticsContext: protocolo não suportado em "${cs}".\n` )
   }
 }

--- a/src/semantic/Table.ts
+++ b/src/semantic/Table.ts
@@ -1,36 +1,70 @@
+import { ISemanticSelectBuilder } from '@core/interfaces/ISemanticSelectBuilder.js';
 import type { IDataSourceAdapter, TableSchema } from '../core/interfaces/IDataSourceAdapter.js' 
 import { TypedColumn } from './TypedColumn.js'
+import { SemanticSelectionItem } from '@builders/semantic/SemanticSelectBuilder.js';
 type QueryFactory = (table: Table, items: any[]) => any;
-/**
- * Representa uma tabela/arquivo com schema conhecido.
- * As colunas são acessíveis como propriedades do objeto.
- *
- * Após: const orders = await ctx.table('orders')
- * Você acessa: orders.seller_name, orders.total_amount, etc.
- *
- * O índice de string ([key: string]) permite acesso dinâmico
- * quando o schema é descoberto em runtime.
- */
+
+export type SelectBuilderFactory = (
+  table: Table,
+  items: SemanticSelectionItem[],
+) => ISemanticSelectBuilder
+
 export class Table {
-  [key: string]: TypedColumn | any  // permite orders.seller_name
+    private readonly _columns: Map<string, TypedColumn> = new Map()
 
   constructor(
     readonly tableName: string,
     readonly schema: TableSchema,
     readonly adapter: IDataSourceAdapter,
-    private readonly factories: { 
-      select: (table: Table, items: any[]) => any 
-      // update?: (table: Table, data: any) => any
-    }
+    private readonly _builderFactory?: SelectBuilderFactory,
   ) {
-    // Registra cada coluna do schema como propriedade do objeto
+
     for (const col of schema.columns) {
-      this[col.name] = new TypedColumn(col.name, col.type, tableName)
+      this._columns.set(
+        col.name,
+        new TypedColumn(col.name, col.type, tableName),
+      )
     }
   }
-  
-  select(items: any[]) {
-    return this.factories.select(this, items)
+  getColumn(name: string): TypedColumn | undefined {
+    return this._columns.get(name)
   }
+
+  get columnNames(): string[] {
+    return [...this._columns.keys()]
+  }
+
+  select(items: SemanticSelectionItem[]) {
+    if (!this._builderFactory) {
+      throw new Error(
+        `Table "${this.tableName}": nenhuma factory registrada. ` +
+        `Crie tabelas via AnalyticsContext.table() em vez de instanciar Table diretamente.`
+      )
+    }
+    return this._builderFactory(this, items)
+  }
+}
   
+export function createTable(
+  tableName: string,
+  schema: TableSchema,
+  adapter: IDataSourceAdapter,
+  builderFactory?: SelectBuilderFactory,
+): Table & Record<string, TypedColumn> {
+  const table = new Table(tableName, schema, adapter, builderFactory)
+
+  return new Proxy(table, {
+    get(target, prop: string | symbol) {
+      // Prioridade 1: métodos e propriedades reais da classe
+      if (prop in target) {
+        const val = (target as any)[prop]
+        return typeof val === 'function' ? val.bind(target) : val
+      }
+      // Prioridade 2: coluna do schema
+      if (typeof prop === 'string') {
+        return target.getColumn(prop)
+      }
+      return undefined
+    },
+  }) as Table & Record<string, TypedColumn>
 }

--- a/src/test/src/builders/semantic/JoinBuilder.test.ts
+++ b/src/test/src/builders/semantic/JoinBuilder.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.js'
+import { Table }       from '@semantic/Table.js'
+import { TypedColumn } from '@semantic/TypedColumn.js'
+import type { IDataSourceAdapter } from '@core/interfaces/IDataSourceAdapter.js'
+import { createTable } from '@semantic/Table.js'
+
+const mockAdapter: IDataSourceAdapter = {
+  execute:    vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  introspect: vi.fn(),
+  close:      vi.fn(),
+}
+
+const factory = (t: any, items: any) =>
+  new SemanticSelectBuilder(t, items, t.adapter)
+const tableVendas = createTable('vendas', {
+  tableName: 'vendas',
+  columns: [
+    { name: 'id',          type: 'number' as const, nullable: false },
+    { name: 'usuario_id',  type: 'number' as const, nullable: false },
+    { name: 'produto_id',  type: 'number' as const, nullable: false },
+    { name: 'total',       type: 'number' as const, nullable: false },
+    { name: 'month',       type: 'date'   as const, nullable: false },
+  ],
+}, mockAdapter, factory)
+
+const tableUsuarios = createTable('usuarios', {
+  tableName: 'usuarios',
+  columns: [
+    { name: 'id',   type: 'number' as const, nullable: false },
+    { name: 'nome', type: 'string' as const, nullable: false },
+  ],
+}, mockAdapter, factory)
+
+const tableProdutos = createTable('produtos', {
+  tableName: 'produtos',
+  columns: [
+    { name: 'id',   type: 'number' as const, nullable: false },
+    { name: 'nome', type: 'string' as const, nullable: false },
+  ],
+}, mockAdapter, factory)
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('JoinBuilder', () => {
+  it('gera INNER JOIN simples', async () => {
+    const vendas   = tableVendas.usuario_id  
+    const usuarios = tableUsuarios.id
+
+    await tableVendas
+      .select([tableVendas.id])
+      .innerJoin(tableUsuarios).on(vendas, usuarios)
+      .fetch()
+
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INNER JOIN usuarios ON vendas.usuario_id = usuarios.id'),
+      []
+    )
+  })
+
+  it('gera LEFT JOIN', async () => {
+    const vendas   = tableVendas.usuario_id
+    const usuarios = tableUsuarios.id
+
+    await tableVendas
+      .select([tableVendas.id])
+      .leftJoin(tableUsuarios).on(vendas, usuarios)
+      .fetch()
+
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('LEFT JOIN'),
+      []
+    )
+  })
+
+  it('gera múltiplos JOINs na mesma query', async () => {
+    await tableVendas
+      .select([tableVendas.id])
+      .innerJoin(tableUsuarios).on(
+        tableVendas.usuario_id,
+        tableUsuarios.id,
+      )
+      .leftJoin(tableProdutos).on(
+        tableVendas.produto_id,
+        tableProdutos.id,
+      )
+      .fetch()
+
+    const sql = (mockAdapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+
+    expect(sql).toContain('INNER JOIN usuarios')
+    expect(sql).toContain('LEFT JOIN produtos')
+  })
+
+  it('JOIN com alias de tabela', async () => {
+    await tableVendas
+      .select([tableVendas.id])
+      .innerJoin(tableUsuarios).as('u').on(
+        tableVendas.usuario_id,
+        tableUsuarios.id,
+      )
+      .fetch()
+
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INNER JOIN usuarios AS u'),
+      []
+    )
+  })
+
+  it('JOIN combinado com WHERE e GROUP BY', async () => {
+    const month = tableVendas.month
+
+    await tableVendas
+      .select([
+        tableVendas.id,
+        (tableUsuarios.nome),
+      ])
+      .innerJoin(tableUsuarios).on(
+        tableVendas.usuario_id,
+        tableUsuarios.id,
+      )
+      .where(month.eq('2026-01'))
+      .groupBy(tableUsuarios.nome)
+      .fetch()
+
+    const sql = (mockAdapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+
+    expect(sql).toContain('INNER JOIN usuarios')
+    expect(sql).toContain('WHERE')
+    expect(sql).toContain('GROUP BY')
+  })
+
+  it('a ordem SQL está correta: FROM → JOIN → WHERE → GROUP BY', async () => {
+    const month = tableVendas.month
+
+    await tableVendas
+      .select([tableVendas.id])
+      .innerJoin(tableUsuarios).on(
+        tableVendas.usuario_id,
+        tableUsuarios.id,
+      )
+      .where(month.eq('2026-01'))
+      .groupBy(tableVendas.id)
+      .fetch()
+
+    const sql = (mockAdapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+
+    const fromPos    = sql.indexOf('FROM')
+    const joinPos    = sql.indexOf('JOIN')
+    const wherePos   = sql.indexOf('WHERE')
+    const groupByPos = sql.indexOf('GROUP BY')
+
+    expect(fromPos).toBeLessThan(joinPos)
+    expect(joinPos).toBeLessThan(wherePos)
+    expect(wherePos).toBeLessThan(groupByPos)
+  })
+})

--- a/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
+++ b/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
@@ -3,6 +3,7 @@ import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.
 import { Table } from  '../../../../semantic/Table.js'
 import { TypedColumn } from '@semantic/TypedColumn.js' 
 import type { IDataSourceAdapter } from '@core/interfaces/IDataSourceAdapter.js'
+import { createTable } from '../../../../semantic/Table.js'
 
 // Mock do adapter — sem banco real
 const mockAdapter: IDataSourceAdapter = {
@@ -22,9 +23,7 @@ const mockSchema = {
   ],
 }
 
-const table = new Table('orders', mockSchema, mockAdapter,{
-  select: (t, items) => new SemanticSelectBuilder(t, items, t.adapter)
-})
+const table = createTable('orders', mockSchema, mockAdapter)
 
 describe('SemanticSelectBuilder', () => {
 


### PR DESCRIPTION
## Descrição do problema

A necessidade de adicionar operações de junções de tabela é importante para que análises mais robustas sejam refletidas no ambiente de desenvolvimento. Assim como as consultas SQL precisam entregar o que é preciso para uma análise de vendas, marketing usando junções de tabelas e outras operações complexas, o Beiju precisa dessa operação não haver limitações claras.

Criar classe/operação join que se integre ao queryBuilder. Um join precisará ter seu próprio alias, reconhecer tabelas e seus IDs que se interligam. Exemplo de como pode se parecer ao final da implementação: 

## Solução proposta

Foi preciso criar classe, builder, alterar lógica SQLGenerator, ajustar SelecBuilder, criar JoinBuilder e adaptar tipagem join (inner join e join se tornaram o que realmente são: a mesma coisa)

## Como testar

rode npx run vitest joinBuilder.tes.ts

## Resultados

Agora o projeto Beiju contempla a junção de tabelas nativamente. Com essa feature, tabelas marginalizadas poderão ser juntas e analisadas na query beiju buildável.

Geral:
- [x] Você revisou seu próprio código?
- [x] Lembrou de não deixar nenhuma linha de código comentado?
- [x] Build está passando?
- [x] Fez testes?