### PR TITLE
BJU-005 | Criar decorator que ativa cláusula rawquery e desenvolver comparativos entre abordagens

### DIFF
--- a/# File Tree: beiju.md
+++ b/# File Tree: beiju.md
@@ -1,7 +1,7 @@
 # File Tree: beiju.js
 
-**Generated:** 07/06/2026, 01:40:59
-**Root Path:** `<repo-root>`
+**Generated:** 19/06/2026, 00:33:52
+**Root Path:** `/Users/juniorteixeira/Documents/Eu/Projetos/beiju.js`
 
 ```
 ├── .github
@@ -11,6 +11,7 @@
 │   ├── builders
 │   │   ├── relational
 │   │   │   ├── AggExprBuilder.ts
+│   │   │   ├── JoinBuilder.ts
 │   │   │   ├── SelectBuilder.ts
 │   │   │   ├── WhereBuilder.ts
 │   │   │   ├── WindowBuilder.ts
@@ -29,19 +30,23 @@
 │   │   │   │   ├── AggregateExpr.ts
 │   │   │   │   └── WindowFunctionExpr.ts
 │   │   │   ├── FrameSpec.ts
+│   │   │   ├── JoinSpec.ts
 │   │   │   ├── OrderByItem.ts
 │   │   │   └── WindowSpec.ts
+│   │   ├── decorators
+│   │   │   └── RawSql.ts
 │   │   ├── interfaces
 │   │   │   ├── IBuilder.ts
 │   │   │   ├── IDataSourceAdapter.ts
 │   │   │   ├── IQueryExecutor.ts
 │   │   │   ├── IQueryNode.ts
+│   │   │   ├── IRawQueryCheck.ts
 │   │   │   ├── ISelectBuilder.ts
+│   │   │   ├── ISemanticSelectBuilder.ts
 │   │   │   ├── ISqlCompileResult.ts
 │   │   │   ├── ISqlDialect.ts
 │   │   │   ├── IWhereBuilder.ts
-│   │   │   ├── IWindowBuilder.ts
-│   │   │   └── QueryExecutor.ts
+│   │   │   └── IWindowBuilder.ts
 │   │   ├── types
 │   │   │   ├── AggFnType.ts
 │   │   │   ├── QueryNodeKindType.ts
@@ -51,9 +56,10 @@
 │   │   │   └── WindowFnType.ts
 │   │   └── ColumnRef.ts
 │   ├── infrastructure
-│   │   └── adapters
-│   │       ├── CsvAdapter.ts
-│   │       └── PgAdapter.ts
+│   │   ├── adapters
+│   │   │   ├── CsvAdapter.ts
+│   │   │   └── PgAdapter.ts
+│   │   └── PgTypeMap.ts
 │   ├── semantic
 │   │   ├── AnalyticsContext.ts
 │   │   ├── ColumnContext.ts
@@ -66,12 +72,20 @@
 │   │   └── src
 │   │       ├── builders
 │   │       │   └── semantic
+│   │       │       ├── JoinBuilder.test.ts
 │   │       │       └── SemanticSelectBuilder.test.ts
 │   │       ├── codegen
 │   │       │   └── SqlGenerator.test.ts
+│   │       ├── core
+│   │       │   └── decorators
+│   │       │       └── RawSql.test.ts
 │   │       └── infrastructure
 │   │           └── adapters
 │   │               └── PgAdapter.test.ts
+│   ├── usecases
+│   │   ├── queryBuilderBenchmarking.ts
+│   │   ├── rawSqlBase.ts
+│   │   └── rawSqlEQueryBuilderBenchmarking.ts
 │   └── index.ts
 ├── # File Tree: beiju.md
 ├── .gitignore

--- a/# File Tree: beiju.md
+++ b/# File Tree: beiju.md
@@ -1,7 +1,7 @@
 # File Tree: beiju.js
 
 **Generated:** 19/06/2026, 00:33:52
-**Root Path:** `/Users/juniorteixeira/Documents/Eu/Projetos/beiju.js`
+**Root Path:** `<repo/private>`
 
 ```
 ├── .github

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .dist
 dist
+*.env

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,404 +8,48 @@
       "name": "beiju",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "pg": "^8.21.0"
       },
       "devDependencies": {
         "@types/pg": "^8.20.0",
         "typescript": "^5.6.3",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^2.1.9"
+        "vitest": "^4.1.9"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -415,24 +59,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -441,12 +100,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -455,12 +117,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -469,26 +134,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -497,12 +151,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -511,26 +168,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -539,12 +185,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -553,40 +202,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -595,54 +219,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -651,12 +236,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -665,12 +253,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -679,26 +270,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -707,12 +287,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -721,26 +323,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -749,26 +340,58 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -795,38 +418,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -838,70 +463,68 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -917,42 +540,22 @@
         "node": ">=12"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -972,61 +575,34 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+      "funding": {
+        "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1046,6 +622,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fsevents": {
@@ -1070,12 +664,266 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1113,22 +961,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT",
       "engines": {
-        "node": ">= 14.16"
+        "node": ">=12.20.0"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.21.0",
@@ -1226,6 +1078,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -1294,49 +1159,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/siginfo": {
@@ -1373,9 +1227,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1387,36 +1241,36 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1444,6 +1298,14 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1466,21 +1328,23 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1489,23 +1353,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -1522,30 +1396,13 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite-tsconfig-paths": {
@@ -1564,58 +1421,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -1626,6 +1504,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "@types/pg": "^8.20.0",
     "typescript": "^5.6.3",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^2.1.9"
+    "vitest": "^4.1.9"
   },
   "dependencies": {
+    "@dotenvx/dotenvx": "^1.73.1",
     "pg": "^8.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "beiju",
   "version": "0.1.0",
+  "engines": {
+    "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+  },
+  "...": "...",
   "private": true,
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@dotenvx/dotenvx": "^1.73.1",
+    "dotenv": "^17.4.2",
     "pg": "^8.21.0"
   }
 }

--- a/src/builders/relational/AggExprBuilder.ts
+++ b/src/builders/relational/AggExprBuilder.ts
@@ -4,13 +4,14 @@ import { AggFnType } from "@core/types/AggFnType.js"
 import { ColumnRef } from "@core/ColumnRef.js" 
 import { WindowBuilderFn, WindowBuilder } from "./WindowBuilder.js"
 
-export class AggExprBuilder {
-  private alias?: string
-  private windowSpec?: WindowSpec
+export type AggColumn = ColumnRef | AggregateExpr
 
+export class AggExprBuilder {
   constructor(
     private readonly fn: AggFnType,
-    private readonly column: ColumnRef,
+    private readonly column: AggColumn,
+    private alias?:     string,
+    private windowSpec?:     WindowSpec,
   ) {}
 
   as(alias: string): this {
@@ -26,6 +27,6 @@ export class AggExprBuilder {
   }
 
   build(): AggregateExpr {
-    return new AggregateExpr(this.fn, this.column, this.alias, this.windowSpec)
+    return new AggregateExpr(this.fn, this.column as any, this.alias, this.windowSpec)
   }
 }

--- a/src/builders/relational/AggExprBuilder.ts
+++ b/src/builders/relational/AggExprBuilder.ts
@@ -10,8 +10,8 @@ export class AggExprBuilder {
   constructor(
     private readonly fn: AggFnType,
     private readonly column: AggColumn,
-    private alias?:     string,
-    private windowSpec?:     WindowSpec,
+    private alias?: string,
+    private windowSpec?: WindowSpec,
   ) {}
 
   as(alias: string): this {
@@ -27,6 +27,6 @@ export class AggExprBuilder {
   }
 
   build(): AggregateExpr {
-    return new AggregateExpr(this.fn, this.column as any, this.alias, this.windowSpec)
+    return new AggregateExpr(this.fn, this.column, this.alias, this.windowSpec)
   }
 }

--- a/src/builders/relational/WindowBuilder.ts
+++ b/src/builders/relational/WindowBuilder.ts
@@ -3,6 +3,7 @@ import { FrameSpec } from '@core/ast/FrameSpec.js'
 import { WindowSpec } from '@core/ast/WindowSpec.js' 
 import { OrderByItem } from '@core/ast/OrderByItem.js' 
 import { IWindowBuilder } from '@core/interfaces/IWindowBuilder.js' 
+import { AggExprBuilder } from './AggExprBuilder.js' 
 export type FrameBoundary = number | 'unbounded' | 'current'
 
 export type WindowBuilderFn = (w: WindowBuilder) => WindowBuilder
@@ -17,11 +18,13 @@ export class WindowBuilder implements IWindowBuilder {
     return this
   }
 
-  orderBy(column: string, direction: 'ASC' | 'DESC' = 'ASC'): this {
-    this.orderByItems.push(
-      new OrderByItem(new ColumnRef(column, 'string'), direction)
-    )
-    return this
+  orderBy(column: string | AggExprBuilder, direction: 'ASC' | 'DESC' = 'ASC'): this {
+    const expr = column instanceof AggExprBuilder
+    ? column.build()                          // AggregateExpr
+    : new ColumnRef(column, 'string')         // ColumnRef
+
+  this.orderByItems.push(new OrderByItem(expr, direction))
+  return this
   }
 
   rowsBetween(start: FrameBoundary, end: FrameBoundary): this {

--- a/src/builders/relational/WindowFnExprBuilder.ts
+++ b/src/builders/relational/WindowFnExprBuilder.ts
@@ -4,6 +4,7 @@ import { WindowFnType } from '@core/types/WindowFnType.js'
 import { WindowSpec } from '@core/ast/WindowSpec.js' 
 import { WindowBuilder } from './WindowBuilder.js'
 import { WindowBuilderFn } from './WindowBuilder.js'
+import { WindowFnColumn } from '@core/ast/expr/WindowFunctionExpr.js'
 
 export class WindowFnExprBuilder {
   private alias?: string
@@ -11,7 +12,7 @@ export class WindowFnExprBuilder {
 
   constructor(
     private readonly fn: WindowFnType,
-    private readonly column?: ColumnRef,
+    private readonly column?: WindowFnColumn,
     private readonly offset?: number,
   ) {}
 

--- a/src/builders/semantic/SemanticSelectBuilder.ts
+++ b/src/builders/semantic/SemanticSelectBuilder.ts
@@ -14,19 +14,13 @@ import { Table } from '../../semantic/Table.js'
 import { JoinSpec } from '@core/ast/JoinSpec.js'
 import { JoinBuilder } from '@builders/relational/JoinBuilder.js'
 import { ISemanticSelectBuilder } from '@core/interfaces/ISemanticSelectBuilder.js'
-/**
- * Tipos aceitos no .select() do SemanticSelectBuilder.
- * O dev passa colunas, agregações ou window functions — sem strings.
- */
+
 export type SemanticSelectionItem =
   | TypedColumn
   | AliasedColumn
   | AggExprBuilder
   | WindowFnExprBuilder
 
-/**
- * Tipos aceitos no .where() do SemanticSelectBuilder.
- */
 export type WhereInput =
   | WhereCondition
   | WhereCondition[]
@@ -70,8 +64,6 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
     private readonly selections: SemanticSelectionItem[],
     private readonly adapter: IDataSourceAdapter,
   ) {}
-
-  // --- Cláusulas encadeáveis ---
 
   where(input: WhereInput): this {
     this.whereInput = input
@@ -124,7 +116,7 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
     return this.selections.map(item => {
       if (item instanceof AggExprBuilder)     return item.build()
       if (item instanceof WindowFnExprBuilder) return item.build()
-      return item.ref  // TypedColumn → ColumnRef
+      return item.ref
     })
   }
 
@@ -135,7 +127,6 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
   private resolveWhere(): SelectQuery['where'] {
     if (!this.whereInput) return undefined
 
-    // Importação inline para evitar dependência circular
     if (this.whereInput instanceof WhereClause) {
       return this.whereInput
     }
@@ -144,7 +135,6 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
       return new WhereClause(this.whereInput, 'AND')
     }
 
-    // Condição única — envolve em WhereClause automaticamente
     return new WhereClause([this.whereInput], 'AND')
   }
 
@@ -161,7 +151,6 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
     )
   }
 
-  // Compila para SQL, executa no adapter e retorna os resultados tipados.
   async fetch<T>(): Promise<T[]> {
     const query = this.build()
     const { sql, params } = SqlGenerator.compile(query)

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -23,7 +23,7 @@ export class SqlGenerator {
       ? `${query.from.table} AS ${query.from.alias}`
       : query.from.table;
 
-    const clauses: string[] = [`SELECT ${selectSql}`, `FROM ${fromSql}`]
+    const clauses: string[] = [`SELECT ${selectSql}`, `FROM ${fromSql}`];
 
     if (query.joins?.length) {
       query.joins.forEach((join) => {
@@ -78,7 +78,18 @@ export class SqlGenerator {
   }
 
   private static compileAggregate(aggregate: AggregateExpr): string {
-    const expr = `${aggregate.fn}(${SqlGenerator.compileColumn(aggregate.column)})`;
+    let innerSql: string;
+
+    if ((aggregate.column as any).kind === "AggregateExpr") {
+      const nested = aggregate.column as unknown as AggregateExpr;
+      const nestedCol = SqlGenerator.compileColumn(nested.column as ColumnRef);
+      innerSql = `${nested.fn}(${nestedCol})`;
+    } else {
+      innerSql = SqlGenerator.compileColumn(aggregate.column as ColumnRef);
+    }
+
+    const expr = `${aggregate.fn}(${innerSql})`;
+
     const withWindow = aggregate.window
       ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}`
       : expr;
@@ -87,19 +98,23 @@ export class SqlGenerator {
   }
 
   private static compileWindowFn(windowFn: WindowFunctionExpr): string {
-    const args: unknown[] = [];
+    const args: string[] = [];
 
     if (windowFn.column) {
-      args.push(SqlGenerator.compileColumn(windowFn.column));
+      if (windowFn.column.kind === "AggregateExpr") {
+        const agg = windowFn.column as AggregateExpr;
+        args.push(`${agg.fn}(${SqlGenerator.compileColumn(agg.column as ColumnRef)})`);
+      } else {
+        args.push(SqlGenerator.compileColumn(windowFn.column as ColumnRef));
+      }
     }
 
     if (typeof windowFn.offset === "number") {
-      args.push(windowFn.offset);
+      args.push(String(windowFn.offset));
     }
 
     const fnExpr = `${windowFn.fn}(${args.join(", ")})`;
     const withWindow = `${fnExpr} ${SqlGenerator.compileWindow(windowFn.window)}`;
-
     return windowFn.alias ? `${withWindow} AS ${windowFn.alias}` : withWindow;
   }
 
@@ -192,10 +207,17 @@ export class SqlGenerator {
     return `${columnSql} ${condition.op} ${valuePlaceholder}`;
   }
 
-  private static compileOrderByItem(
-    item: { column: ColumnRef; direction: "ASC" | "DESC" } | OrderByItem,
-  ): string {
-    return `${SqlGenerator.compileColumn(item.column)} ${item.direction}`;
+  private static compileOrderByItem(item: OrderByItem): string {
+    let exprSql: string;
+
+    if (item.expr.kind === "AggregateExpr") {
+      const agg = item.expr as AggregateExpr;
+      exprSql = `${agg.fn}(${SqlGenerator.compileColumn(agg.column as ColumnRef)})`;
+    } else {
+      exprSql = SqlGenerator.compileColumn(item.expr as ColumnRef);
+    }
+
+    return `${exprSql} ${item.direction}`;
   }
 
   private static pushParam(params: unknown[], value: unknown): string {
@@ -204,15 +226,18 @@ export class SqlGenerator {
   }
 
   private static compileJoin(join: JoinSpec): string {
-    const tableRef = join.alias 
-    ? `${join.table} AS ${join.alias}` 
-    : join.table;
+    const tableRef = join.alias ? `${join.table} AS ${join.alias}` : join.table;
 
     const conditions = join.conditions
-      .map((c) => `${SqlGenerator.compileColumn(c.left)} ${c.op} ${SqlGenerator.compileColumn(c.right)}`)
+      .map(
+        (c) =>
+          `${SqlGenerator.compileColumn(c.left)} ${c.op} ${SqlGenerator.compileColumn(c.right)}`,
+      )
       .join(" AND ");
 
-    const returnJoin = join.type ? `${join.type} JOIN ${tableRef} ON ${conditions}` : `JOIN ${tableRef} ON ${conditions}`
+    const returnJoin = join.type
+      ? `${join.type} JOIN ${tableRef} ON ${conditions}`
+      : `JOIN ${tableRef} ON ${conditions}`;
 
     return returnJoin;
   }

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -54,7 +54,7 @@ export class SqlGenerator {
     if (typeof query.offset === "number") {
       clauses.push(`OFFSET ${query.offset}`);
     }
-
+ 
     return {
       sql: clauses.join(" "),
       params,
@@ -78,35 +78,33 @@ export class SqlGenerator {
   }
 
   private static compileAggregate(aggregate: AggregateExpr): string {
-    let innerSql: string;
-
-    if ((aggregate.column as any).kind === "AggregateExpr") {
-      const nested = aggregate.column as unknown as AggregateExpr;
-      const nestedCol = SqlGenerator.compileColumn(nested.column as ColumnRef);
-      innerSql = `${nested.fn}(${nestedCol})`;
-    } else {
-      innerSql = SqlGenerator.compileColumn(aggregate.column as ColumnRef);
-    }
-
-    const expr = `${aggregate.fn}(${innerSql})`;
+    const expr = `${aggregate.fn}(${SqlGenerator.compileAggColumn(aggregate.column)})`
 
     const withWindow = aggregate.window
-      ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}`
-      : expr;
+    ? `${expr} ${SqlGenerator.compileWindow(aggregate.window)}`
+    : expr
+    
+    return aggregate.alias ? `${withWindow} AS ${aggregate.alias}` : withWindow
+  }
 
-    return aggregate.alias ? `${withWindow} AS ${aggregate.alias}` : withWindow;
+  //compila agregação e apenas coluna (entende os tipos e desmembra o aninhamento com recursividade)
+  private static compileAggColumn(column: ColumnRef | AggregateExpr): string {
+  if (column.kind === 'AggregateExpr') {
+    const inner = SqlGenerator.compileAggColumn(column.column)
+    return `${column.fn}(${inner})`
+  }
+  return SqlGenerator.compileColumn(column)
   }
 
   private static compileWindowFn(windowFn: WindowFunctionExpr): string {
     const args: string[] = [];
 
     if (windowFn.column) {
-      if (windowFn.column.kind === "AggregateExpr") {
-        const agg = windowFn.column as AggregateExpr;
-        args.push(`${agg.fn}(${SqlGenerator.compileColumn(agg.column as ColumnRef)})`);
-      } else {
-        args.push(SqlGenerator.compileColumn(windowFn.column as ColumnRef));
-      }
+      args.push(SqlGenerator.compileAggColumn(windowFn.column));
+    }
+
+    if (typeof windowFn.offset === "number") {
+      args.push(String(windowFn.offset));
     }
 
     if (typeof windowFn.offset === "number") {
@@ -115,6 +113,7 @@ export class SqlGenerator {
 
     const fnExpr = `${windowFn.fn}(${args.join(", ")})`;
     const withWindow = `${fnExpr} ${SqlGenerator.compileWindow(windowFn.window)}`;
+
     return windowFn.alias ? `${withWindow} AS ${windowFn.alias}` : withWindow;
   }
 
@@ -208,14 +207,7 @@ export class SqlGenerator {
   }
 
   private static compileOrderByItem(item: OrderByItem): string {
-    let exprSql: string;
-
-    if (item.expr.kind === "AggregateExpr") {
-      const agg = item.expr as AggregateExpr;
-      exprSql = `${agg.fn}(${SqlGenerator.compileColumn(agg.column as ColumnRef)})`;
-    } else {
-      exprSql = SqlGenerator.compileColumn(item.expr as ColumnRef);
-    }
+    const exprSql = SqlGenerator.compileAggColumn(item.expr)
 
     return `${exprSql} ${item.direction}`;
   }

--- a/src/core/ast/OrderByItem.ts
+++ b/src/core/ast/OrderByItem.ts
@@ -1,10 +1,13 @@
 import { ColumnRef } from "../ColumnRef.js" 
+import { AggregateExpr } from "./expr/AggregateExpr.js"
+
+export type OrderByExpr = ColumnRef | AggregateExpr
 
 export class OrderByItem {
   readonly kind = 'OrderByItem' as const
 
   constructor(
-    readonly column: ColumnRef,
-    readonly direction: 'ASC' | 'DESC' = 'ASC',
+    readonly expr: OrderByExpr,
+    readonly direction: 'ASC' | 'DESC' = 'ASC'
   ) {}
 }

--- a/src/core/ast/clause/SelectQuery.ts
+++ b/src/core/ast/clause/SelectQuery.ts
@@ -1,4 +1,3 @@
-// domain/model/SelectQuery.ts
 import { ColumnRef } from '../../ColumnRef.js'; 
 import { WhereClause } from './WhereClause.js'
 import { OrderByItem } from '../OrderByItem.js';

--- a/src/core/ast/expr/AggregateExpr.ts
+++ b/src/core/ast/expr/AggregateExpr.ts
@@ -4,12 +4,14 @@ import { SqlType } from '../../types/SqlType.js'
 import { WindowSpec } from '../WindowSpec.js' 
 import { AggFnType } from '../../types/AggFnType.js' 
 
+export type AggColumn = ColumnRef | AggregateExpr
+
 export class AggregateExpr<T extends SqlType = SqlType> {
   readonly kind = 'AggregateExpr' as const
 
   constructor(
     readonly fn: AggFnType,
-    readonly column: ColumnRef<T>,
+    readonly column: AggColumn,
     readonly alias?: string,
     readonly window?: WindowSpec,
   ) {}

--- a/src/core/ast/expr/WindowFunctionExpr.ts
+++ b/src/core/ast/expr/WindowFunctionExpr.ts
@@ -2,6 +2,10 @@ import { ColumnRef } from '../../ColumnRef.js'
 import { SqlType } from '../../types/SqlType.js' 
 import { WindowSpec } from '../WindowSpec.js'
 import { WindowFnType } from '../../types/WindowFnType.js' 
+import { AggregateExpr } from './AggregateExpr.js'
+
+export type WindowFnColumn = ColumnRef | AggregateExpr  
+
 
 export class WindowFunctionExpr<T extends SqlType = SqlType> {
   readonly kind = 'WindowFunctionExpr' as const
@@ -9,7 +13,7 @@ export class WindowFunctionExpr<T extends SqlType = SqlType> {
   constructor(
     readonly fn: WindowFnType,
     readonly window: WindowSpec,
-    readonly column?: ColumnRef<T>,
+    readonly column?: WindowFnColumn,
     readonly offset?: number,
     readonly alias?: string,
   ) {}

--- a/src/core/decorators/RawSql.ts
+++ b/src/core/decorators/RawSql.ts
@@ -32,8 +32,8 @@ export function RawSql(sql: string) {
           `Verifique se o adapter utilizado implementa IQueryExecutor corretamente.`
         )
       }
-
-      const params = args.filter(arg => arg !== undefined)
+      
+      const params = args.map(arg => arg === undefined ? null : arg)
 
       const result = await executor.executeRaw(sql, params)
       return result.rows

--- a/src/core/decorators/RawSql.ts
+++ b/src/core/decorators/RawSql.ts
@@ -1,0 +1,44 @@
+import type { IQueryExecutor } from '../interfaces/IQueryExecutor.js'
+
+export function RawSql(sql: string) {
+  return function (
+    target: object,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ): PropertyDescriptor {
+
+    if (!sql || sql.trim().length === 0) {
+      throw new Error(
+        `@RawSql em "${String(propertyKey)}": a query SQL não pode ser vazia.`
+      )
+    }
+
+    descriptor.value = async function (this: any, ...args: unknown[]) {
+
+      const executor: IQueryExecutor | undefined =
+        this.executor ?? this.adapter ?? this._executor
+
+      if (!executor) {
+        throw new Error(
+          `@RawSql em "${String(propertyKey)}": nenhum IQueryExecutor encontrado na instância. ` +
+          `A classe deve expor uma propriedade "executor" do tipo IQueryExecutor.\n` +
+          `Exemplo: constructor(readonly executor: IQueryExecutor) {}`
+        )
+      }
+
+      if (typeof executor.executeRaw !== 'function') {
+        throw new Error(
+          `@RawSql em "${String(propertyKey)}": o executor encontrado não implementa executeRaw(). ` +
+          `Verifique se o adapter utilizado implementa IQueryExecutor corretamente.`
+        )
+      }
+
+      const params = args.filter(arg => arg !== undefined)
+
+      const result = await executor.executeRaw(sql, params)
+      return result.rows
+    }
+
+    return descriptor
+  }
+}

--- a/src/core/interfaces/IQueryExecutor.ts
+++ b/src/core/interfaces/IQueryExecutor.ts
@@ -8,5 +8,8 @@ export interface IQueryExecutor {
     sql: string, 
     params: unknown[]
   ): Promise<IQueryResult<T>>;
+
+  executeRaw<T = any>(sql: string, params?: unknown[]): Promise<IQueryResult<T>>
+
   close(): Promise<void>
-}
+} 

--- a/src/core/interfaces/IRawQueryCheck.ts
+++ b/src/core/interfaces/IRawQueryCheck.ts
@@ -1,0 +1,5 @@
+import type { IQueryExecutor } from './IQueryExecutor.js'
+
+export interface IRawQueryCheck {
+  readonly executor: IQueryExecutor
+}

--- a/src/core/interfaces/ISemanticSelectBuilder.ts
+++ b/src/core/interfaces/ISemanticSelectBuilder.ts
@@ -1,5 +1,7 @@
 import { JoinBuilder } from "@builders/relational/JoinBuilder.js"
 import { Table } from "@semantic/Table.js"
+import { SelectQuery } from "@core/ast/clause/SelectQuery.js"
+
 /**
  * Contrato mínimo do SemanticSelectBuilder.
  * Usado como tipo de retorno da SelectBuilderFactory em Table.ts
@@ -7,6 +9,7 @@ import { Table } from "@semantic/Table.js"
  */
 export interface ISemanticSelectBuilder {
   fetch<T>(): Promise<T[]>
+  build(): SelectQuery 
   where(input: unknown): this
   groupBy(...columns: unknown[]): this
   orderBy(column: unknown, direction?: 'ASC' | 'DESC'): this

--- a/src/core/interfaces/QueryExecutor.ts
+++ b/src/core/interfaces/QueryExecutor.ts
@@ -1,9 +1,0 @@
-export interface QueryResult<T> {
-  readonly rows: T[]
-  readonly rowCount: number
-}
-
-export interface QueryExecutor {
-  execute<T>(sql: string, params: unknown[]): Promise<QueryResult<T>>
-  close(): Promise<void>
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,47 @@
+export { AnalyticsContext } from './semantic/AnalyticsContext.js'
+export { createTable } from './semantic/Table.js'
+export { TypedColumn } from './semantic/TypedColumn.js'
+export { RawSql } from './core/decorators/RawSql.js'
+import { WindowFnExprBuilder } from './builders/relational/WindowFnExprBuilder.js';
+import { ColumnRef } from '@core/ColumnRef.js'; 
+import { AggExprBuilder } from '@builders/relational/AggExprBuilder.js';
+import { TypedColumn } from './semantic/TypedColumn.js';
+import 'dotenv/config'
+
+export const lag = (col: string | AggExprBuilder, offset = 1) => {
+    const columnExpr = col instanceof AggExprBuilder
+        ? col.build()                       
+        : new ColumnRef(col, 'number') 
+
+    return new WindowFnExprBuilder('LAG', columnExpr, offset);
+}
+export const rank = () => {
+  return new WindowFnExprBuilder('RANK');
+}
+export const denseRank = () => {
+  return new WindowFnExprBuilder('DENSE_RANK');
+}
+export const rowNumber = () => {
+  return new WindowFnExprBuilder('ROW_NUMBER');
+}
+export const lead = (col: string, offset = 1) => {
+  return new WindowFnExprBuilder('LEAD', new ColumnRef(col, 'number'), offset);
+};
+
+export const avg = (col: string | TypedColumn | AggExprBuilder) => {
+  if (col instanceof AggExprBuilder) {
+
+    return new AggExprBuilder('AVG', col.build() as any)
+  }
+  if (col instanceof TypedColumn) {
+
+    return new AggExprBuilder('AVG', col.ref)
+  }
+
+  return new AggExprBuilder('AVG', new ColumnRef(col, 'number'))
+}
+export { PgAdapter }from './infrastructure/adapters/PgAdapter.js'
+
+export type { IQueryExecutor } from './core/interfaces/IQueryExecutor.js'
+export type { IQueryResult }   from './core/interfaces/IQueryExecutor.js'
+export type { IRawQueryCheck } from './core/interfaces/IRawQueryCheck.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { WindowFnExprBuilder } from './builders/relational/WindowFnExprBuilder.j
 import { ColumnRef } from '@core/ColumnRef.js'; 
 import { AggExprBuilder } from '@builders/relational/AggExprBuilder.js';
 import { TypedColumn } from './semantic/TypedColumn.js';
-import 'dotenv/config'
 
 export const lag = (col: string | AggExprBuilder, offset = 1) => {
     const columnExpr = col instanceof AggExprBuilder

--- a/src/infrastructure/PgTypeMap.ts
+++ b/src/infrastructure/PgTypeMap.ts
@@ -1,0 +1,31 @@
+import { ColumnSchema } from "@core/interfaces/IDataSourceAdapter.js"
+
+export const PG_TYPE_MAP: Record<string, ColumnSchema['type']> = {
+  integer:          'number',
+  int4:             'number',
+  int8:             'number',
+  bigint:           'number',
+  smallint:         'number',
+  numeric:          'number',
+  decimal:          'number',
+  real:             'number',
+  float4:           'number',
+  float8:           'number',
+  'double precision': 'number',
+
+  text:             'string',
+  varchar:          'string',
+  'character varying': 'string',
+  char:             'string',
+  bpchar:           'string',
+  uuid:             'string',
+
+  date:             'date',
+  timestamp:        'date',
+  timestamptz:      'date',
+  'timestamp without time zone': 'date',
+  'timestamp with time zone':    'date',
+
+  bool:             'boolean',
+  boolean:          'boolean',
+}

--- a/src/infrastructure/adapters/PgAdapter.ts
+++ b/src/infrastructure/adapters/PgAdapter.ts
@@ -1,42 +1,10 @@
 import { Pool, type PoolConfig } from 'pg'
 import type { IDataSourceAdapter } from '../../core/interfaces/IDataSourceAdapter.js' 
 import type { TableSchema, ColumnSchema } from '../../core/interfaces/IDataSourceAdapter.js' 
-import type { QueryResult } from '../../core/interfaces/QueryExecutor.js'
+import type { IQueryResult } from '@core/interfaces/IQueryExecutor.js' 
 import { QueryResultRow } from 'pg'
+import { PG_TYPE_MAP } from '@infrastructure/PgTypeMap.js'
 
-const PG_TYPE_MAP: Record<string, ColumnSchema['type']> = {
-  integer:          'number',
-  int4:             'number',
-  int8:             'number',
-  bigint:           'number',
-  smallint:         'number',
-  numeric:          'number',
-  decimal:          'number',
-  real:             'number',
-  float4:           'number',
-  float8:           'number',
-  'double precision': 'number',
-
-  text:             'string',
-  varchar:          'string',
-  'character varying': 'string',
-  char:             'string',
-  bpchar:           'string',
-  uuid:             'string',
-
-  date:             'date',
-  timestamp:        'date',
-  timestamptz:      'date',
-  'timestamp without time zone': 'date',
-  'timestamp with time zone':    'date',
-
-  bool:             'boolean',
-  boolean:          'boolean',
-}
-
-/**
- * Linha retornada pela consulta ao information_schema.columns
- */
 interface InformationSchemaRow {
   column_name: string
   data_type: string
@@ -62,7 +30,6 @@ export class PgAdapter implements IDataSourceAdapter {
       console.error('[PgAdapter] Erro inesperado no pool de conexões:', err)
     })
   }
-
   static getInstance(connectionString: string): PgAdapter {
     if (!PgAdapter.instances.has(connectionString)) {
       PgAdapter.instances.set(connectionString, new PgAdapter(connectionString))
@@ -76,7 +43,7 @@ export class PgAdapter implements IDataSourceAdapter {
    * @param sql    — string SQL com placeholders ($1, $2, ...)
    * @param params — valores correspondentes aos placeholders
    */
-  async execute<T extends QueryResultRow>(sql: string, params: unknown[]): Promise<QueryResult<T>> {
+  async execute<T extends QueryResultRow>(sql: string, params: unknown[]): Promise<IQueryResult<T>> {
     const client = await this.pool.connect()
 
     try {
@@ -89,6 +56,22 @@ export class PgAdapter implements IDataSourceAdapter {
       client.release()
     }
   }
+
+  async executeRaw<T = any>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<IQueryResult<T>> {
+  const client = await this.pool.connect()
+  try {
+    const result = await client.query(sql, params as any[])
+    return {
+      rows: result.rows,
+      rowCount: result.rowCount ?? 0,
+    }
+  } finally {
+    client.release()
+  }
+}
 
   /**
    * Introspecta o schema de uma tabela consultando o information_schema.

--- a/src/semantic/AnalyticsContext.ts
+++ b/src/semantic/AnalyticsContext.ts
@@ -4,17 +4,9 @@ import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.
 import { Table } from './Table.js' 
 import { TypedColumn } from './TypedColumn.js'
 import { createTable } from './Table.js'
-/**
- * Ponto de entrada do Beiju.
- * Recebe uma connection string e instancia o adapter correto.
- *
- * Exemplos de connection string:
- *   postgresql://user:pass@localhost:5432/mydb
- *   csv://./data/orders.csv
- *   parquet://./data/orders.parquet
- */
+
 export class AnalyticsContext {
-  private readonly adapter: IDataSourceAdapter
+  readonly adapter: IDataSourceAdapter
 
   constructor(connectionString: string) {
     this.adapter = AnalyticsContext.resolveAdapter(connectionString)
@@ -22,7 +14,9 @@ export class AnalyticsContext {
   async table(name: string): Promise<Table & Record<string, TypedColumn>> {
     const schema = await this.adapter.introspect(name)
     
-    return createTable(name, schema, this.adapter)
+    return createTable(name, schema, this.adapter, (t, items) =>
+      new SemanticSelectBuilder(t, items, t.adapter)
+    )
   }
 
   private static resolveAdapter(cs: string): IDataSourceAdapter {
@@ -30,6 +24,9 @@ export class AnalyticsContext {
         return PgAdapter.getInstance(cs);
     
     }
-    throw new Error(`AnalyticsContext: protocolo não suportado em "${cs}".\n` )
+   throw new Error(
+      `AnalyticsContext: protocolo não suportado em "${cs}".\n` +
+      `Protocolos aceitos: postgresql://`
+    )
   }
 }

--- a/src/semantic/AnalyticsContext.ts
+++ b/src/semantic/AnalyticsContext.ts
@@ -24,9 +24,9 @@ export class AnalyticsContext {
         return PgAdapter.getInstance(cs);
     
     }
-   throw new Error(
+    throw new Error(
       `AnalyticsContext: protocolo não suportado em "${cs}".\n` +
-      `Protocolos aceitos: postgresql://`
+      `Protocolos aceitos: postgresql://, postgres://`
     )
   }
 }

--- a/src/test/src/builders/semantic/JoinBuilder.test.ts
+++ b/src/test/src/builders/semantic/JoinBuilder.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.js'
-import { Table }       from '@semantic/Table.js'
-import { TypedColumn } from '@semantic/TypedColumn.js'
 import type { IDataSourceAdapter } from '@core/interfaces/IDataSourceAdapter.js'
 import { createTable } from '@semantic/Table.js'
 
 const mockAdapter: IDataSourceAdapter = {
   execute:    vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  executeRaw: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
   introspect: vi.fn(),
   close:      vi.fn(),
 }

--- a/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
+++ b/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { SemanticSelectBuilder } from '@builders/semantic/SemanticSelectBuilder.js' 
-import { Table } from  '../../../../semantic/Table.js'
-import { TypedColumn } from '@semantic/TypedColumn.js' 
 import type { IDataSourceAdapter } from '@core/interfaces/IDataSourceAdapter.js'
 import { createTable } from '../../../../semantic/Table.js'
 
-// Mock do adapter — sem banco real
 const mockAdapter: IDataSourceAdapter = {
   execute:    vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  executeRaw: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
   introspect: vi.fn(),
   close:      vi.fn(),
 }
 
-// Schema simulado — como viria do PgAdapter.introspect()
 const mockSchema = {
   tableName: 'orders',
   columns: [
@@ -32,7 +28,7 @@ describe('SemanticSelectBuilder', () => {
   })
 
   it('gera SQL de SELECT simples com coluna tipada', async () => {
-    await table.select([table.seller_name as TypedColumn])
+    await table.select([table.seller_name])
       .fetch()
 
     expect(mockAdapter.execute).toHaveBeenCalledWith(
@@ -42,10 +38,10 @@ describe('SemanticSelectBuilder', () => {
   })
 
   it('gera SQL com WHERE usando coluna tipada', async () => {
-    const month = table.month as TypedColumn
+    const month = table.month
 
     await table
-      .select([table.seller_name as TypedColumn])
+      .select([table.seller_name])
       .where(month.eq('2026-01'))
       .fetch()
 
@@ -56,8 +52,8 @@ describe('SemanticSelectBuilder', () => {
   })
 
   it('gera SQL com GROUP BY e agregação', async () => {
-    const sellerName  = table.seller_name  as TypedColumn
-    const totalAmount = table.total_amount as TypedColumn
+    const sellerName  = table.seller_name
+    const totalAmount = table.total_amount
 
     await table
       .select([
@@ -74,20 +70,19 @@ describe('SemanticSelectBuilder', () => {
   })
 
     it("gera SQL com RANK e OVER", async () => {
-      const totalAmount = table.total_amount as TypedColumn;
+      const totalAmount = table.total_amount
 
       await table
         .select([totalAmount.sum().as("total_vendas"), totalAmount])
         .fetch();
 
-      // Valida que o adapter foi chamado — SQL verificado no SqlGenerator.test.ts
       expect(mockAdapter.execute).toHaveBeenCalledOnce();
     });
    
 
   it('respeita LIMIT e OFFSET', async () => {
     await table
-      .select([table.seller_name as TypedColumn])
+      .select([table.seller_name])
       .limit(10)
       .offset(20)
       .fetch()
@@ -103,8 +98,8 @@ describe('SemanticSelectBuilder', () => {
   })
 
   it('encadeia ORDER BY corretamente', async () => {
-    const sellerName  = table.seller_name  as TypedColumn
-    const totalAmount = table.total_amount as TypedColumn
+    const sellerName  = table.seller_name
+    const totalAmount = table.total_amount
 
     await table
       .select([sellerName])

--- a/src/test/src/codegen/SqlGenerator.test.ts
+++ b/src/test/src/codegen/SqlGenerator.test.ts
@@ -81,7 +81,7 @@ describe('SqlGenerator', () => {
             orderBy: [
               {
                 kind: 'OrderByItem' as const,
-                expr: new columnRef('total_amount', 'number', 'o'),
+                expr: new columnRef('month', 'number', 'o'),
                 direction: 'ASC' as const,
               },
             ],
@@ -112,7 +112,7 @@ describe('SqlGenerator', () => {
             orderBy: [
               {
                 kind: 'OrderByItem' as const,
-                expr: new columnRef('nome_da_coluna_de_ordenacao', 'number', 'o'), 
+                expr: new columnRef('total_amount', 'number', 'o'), 
                 direction: 'DESC' as const,
               },
             ],

--- a/src/test/src/codegen/SqlGenerator.test.ts
+++ b/src/test/src/codegen/SqlGenerator.test.ts
@@ -94,7 +94,7 @@ describe('SqlGenerator', () => {
     const compiled = SqlGenerator.compile(query)
 
     expect(compiled).toEqual({
-      sql: 'SELECT RANK() OVER (ORDER BY o.total_amount DESC) AS ranking, LAG(o.total_amount, 1) OVER (ORDER BY o.month ASC) AS prev_month FROM orders AS o',
+      sql: 'SELECT RANK() OVER (ORDER BY o.total_amount DESC) AS ranking, LAG(o.total_amount, 1, 1) OVER (ORDER BY o.month ASC) AS prev_month FROM orders AS o',
       params: [],
     })
   })
@@ -129,4 +129,14 @@ describe('SqlGenerator', () => {
       params: [],
     })
   })
+
+  it("compila agregação duplamente aninhada corretamente", () => {
+    const nested = new AggregateExpr(
+      "AVG",
+      new AggregateExpr("SUM", new ColumnRef("total", "number", "vendas")),
+    );
+
+    const sql = (SqlGenerator as any).compileAggregate(nested);
+    expect(sql).toBe("AVG(SUM(vendas.total))");
+  });
 })

--- a/src/test/src/codegen/SqlGenerator.test.ts
+++ b/src/test/src/codegen/SqlGenerator.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
-
 import { ColumnRef, ColumnRef as columnRef } from '@core/ColumnRef.js';
 import { SqlGenerator } from '@codegen/SqlGenerator.js'; 
+import { OrderByExpr } from '@core/ast/OrderByItem.js';
+import { AggregateExpr } from '@core/ast/expr/AggregateExpr.js';
 
 export function columRefParamns(column: string, type: any, table?: string ): ColumnRef{
 
@@ -51,6 +52,7 @@ describe('SqlGenerator', () => {
   })
 
   it('gera SELECT com Window Function RANK e LAG', () => {
+
     const query = {
       from: { table: 'orders', alias: 'o'},
       select: [
@@ -62,7 +64,7 @@ describe('SqlGenerator', () => {
             orderBy: [
               {
                 kind: 'OrderByItem' as const,
-                column: new columnRef('total_amount', 'number', 'o'),
+                expr: new columnRef('total_amount', 'number', 'o'),
                 direction: 'DESC' as const,
               },
             ],
@@ -79,7 +81,7 @@ describe('SqlGenerator', () => {
             orderBy: [
               {
                 kind: 'OrderByItem' as const,
-                column: new columnRef('month', 'string', 'o'),
+                expr: new columnRef('total_amount', 'number', 'o'),
                 direction: 'ASC' as const,
               },
             ],
@@ -110,7 +112,7 @@ describe('SqlGenerator', () => {
             orderBy: [
               {
                 kind: 'OrderByItem' as const,
-                column: new columnRef('total_amount', 'number', 'o'),
+                expr: new columnRef('nome_da_coluna_de_ordenacao', 'number', 'o'), 
                 direction: 'DESC' as const,
               },
             ],

--- a/src/test/src/core/decorators/RawSql.test.ts
+++ b/src/test/src/core/decorators/RawSql.test.ts
@@ -22,6 +22,13 @@ class UserRepository implements IRawQueryCheck{
 
   @RawSql('SELECT * FROM users WHERE salary > $1 AND active = $2')
   async getBySalaryAndStatus(salary: number, active: boolean): Promise<any[]> { return [] }
+
+  @RawSql('SELECT * FROM users WHERE region = $1 AND active = $2')
+  async getByRegionAndAtive(region: string, active: boolean): Promise<any[]> { 
+    return [] 
+}
+
+
 }
 
 describe('@RawSql decorator', () => {
@@ -99,4 +106,14 @@ describe('@RawSql decorator', () => {
     expect(mockExecutor.execute).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledOnce()
   })
+
+  it('preserva a posição dos parâmetros mesmo com undefined no meio', async () => {
+  await repo.getByRegionAndAtive(undefined, true)
+
+  expect(mockExecuteRaw).toHaveBeenCalledWith(
+    'SELECT * FROM users WHERE region = $1 AND active = $2',
+    [null, true]
+  )
+ })
+
 })

--- a/src/test/src/core/decorators/RawSql.test.ts
+++ b/src/test/src/core/decorators/RawSql.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RawSql } from '@core/decorators/RawSql.js'
+import type { IQueryExecutor, IQueryResult } from '@core/interfaces/IQueryExecutor.js'
+import { IRawQueryCheck } from '@core/interfaces/IRawQueryCheck.js'
+
+const mockExecuteRaw = vi.fn()
+const mockExecutor: IQueryExecutor = {
+  execute:    vi.fn(),
+  executeRaw: mockExecuteRaw,
+  close:      vi.fn(),
+}
+
+// Exemplo de classe usando o @RawSql
+class UserRepository implements IRawQueryCheck{
+  constructor(readonly executor: IQueryExecutor) {}
+
+  @RawSql('SELECT * FROM users')
+  async getAll(): Promise<any[]> { return [] }
+
+  @RawSql('SELECT * FROM users WHERE salary > $1')
+  async getBySalary(salary: number): Promise<any[]> { return [] }
+
+  @RawSql('SELECT * FROM users WHERE salary > $1 AND active = $2')
+  async getBySalaryAndStatus(salary: number, active: boolean): Promise<any[]> { return [] }
+}
+
+describe('@RawSql decorator', () => {
+  let repo: UserRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExecuteRaw.mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 })
+    repo = new UserRepository(mockExecutor)
+  })
+
+  it('chama executeRaw com o SQL correto sem params', async () => {
+    await repo.getAll()
+
+    expect(mockExecuteRaw).toHaveBeenCalledWith(
+      'SELECT * FROM users',
+      []
+    )
+  })
+
+  it('passa os argumentos do método como params posicionais', async () => {
+    await repo.getBySalary(1000)
+
+    expect(mockExecuteRaw).toHaveBeenCalledWith(
+      'SELECT * FROM users WHERE salary > $1',
+      [1000]
+    )
+  })
+
+  it('passa múltiplos argumentos como params na ordem correta', async () => {
+    await repo.getBySalaryAndStatus(1000, true)
+
+    expect(mockExecuteRaw).toHaveBeenCalledWith(
+      'SELECT * FROM users WHERE salary > $1 AND active = $2',
+      [1000, true]
+    )
+  })
+
+  it('retorna as rows do resultado', async () => {
+    mockExecuteRaw.mockResolvedValue({
+      rows: [{ id: 1, name: 'Junior' }],
+      rowCount: 1,
+    })
+
+    const result = await repo.getAll()
+
+    expect(result).toEqual([{ id: 1, name: 'Junior' }])
+  })
+
+  it('lança erro se a classe não tiver executor', async () => {
+    class SemExecutor {
+      @RawSql('SELECT 1')
+      async query(): Promise<any[]> { return [] }
+    }
+
+    const sem = new SemExecutor()
+    await expect(sem.query()).rejects.toThrow(
+      'nenhum IQueryExecutor encontrado'
+    )
+  })
+
+  it('lança erro se o SQL for vazio', () => {
+    expect(() => {
+      class Invalida {
+        constructor(readonly executor: IQueryExecutor) {}
+        @RawSql('')
+        async query(): Promise<any[]> { return [] }
+      }
+    }).toThrow('a query SQL não pode ser vazia')
+  })
+
+  it('não chama execute — apenas executeRaw', async () => {
+    await repo.getAll()
+
+    expect(mockExecutor.execute).not.toHaveBeenCalled()
+    expect(mockExecuteRaw).toHaveBeenCalledOnce()
+  })
+})

--- a/src/usecases/queryBuilderBenchmarking.ts
+++ b/src/usecases/queryBuilderBenchmarking.ts
@@ -1,0 +1,25 @@
+import { AnalyticsContext } from "@semantic/AnalyticsContext.js"
+import { rank } from "../index.js"
+import { lag } from "../index.js"
+import 'dotenv/config'
+
+const ctx = new AnalyticsContext(process.env.DB_STRING_CONNECTION)
+
+const vendas = await ctx.table('vendas')
+
+const resultado = await vendas
+  .select([
+    vendas.vendedor_id,
+    vendas.mes,
+    vendas.total.sum().as('total_vendas'),
+    rank()
+      .over(w => w.partitionBy('mes').orderBy(vendas.total.sum(), 'DESC'))
+      .as('ranking'),
+    lag(vendas.total.sum(), 1)
+      .over(w => w.partitionBy('vendedor_id').orderBy('mes'))
+      .as('mes_anterior'),
+  ])
+  .groupBy(vendas.vendedor_id, vendas.mes)
+  .fetch()
+
+console.table(resultado)

--- a/src/usecases/rawSqlBase.ts
+++ b/src/usecases/rawSqlBase.ts
@@ -1,0 +1,76 @@
+import { RawSql } from '@core/decorators/RawSql.js'
+import type { IQueryExecutor } from '@core/interfaces/IQueryExecutor.js'
+import { IRawQueryCheck } from '@core/interfaces/IRawQueryCheck.js'
+import { PgAdapter } from '@infrastructure/adapters/PgAdapter.js'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import 'dotenv/config'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+class VendasRepository {
+  constructor(readonly executor: IQueryExecutor) {}
+
+  @RawSql('SELECT * FROM vendas')
+  async listarTodas(): Promise<any[]> { 
+    return []
+  }
+
+  @RawSql('SELECT * FROM vendas WHERE vendedor_id = $1')
+  async listarPorVendedor(vendedorId: number): Promise<any[]> { 
+    return []
+  }
+
+  @RawSql('SELECT * FROM vendas WHERE mes = $1 AND total > $2')
+  async listarPorMesEValor(mes: string, total: number): Promise<any[]> { 
+    return []
+  }
+
+  @RawSql('SELECT vendas.id, vendas.produto FROM vendas WHERE produto = $1')
+  async listarProdutoPorNomeProduto(produto: string){
+     return []
+    }
+  
+}
+
+async function main() {
+  const executor = PgAdapter.getInstance(CONNECTION_STRING)
+  const repo = new VendasRepository(executor)
+  const ctx = new AnalyticsContext(CONNECTION_STRING)
+
+  console.log('\n── Iniciando métodos RawSQL Beiju ──────────────────────────\n')
+
+  try {
+    console.log('[1] listarTodas()')
+    const todas = await repo.listarTodas()
+    console.log(`    → ${todas.length} registros retornados`)
+    console.table(todas.slice(0, 3))
+
+    console.log('[2] listarPorVendedor(1)')
+    const porVendedor = await repo.listarPorVendedor(1)
+    console.log(`    → ${porVendedor.length} registros retornados`)
+    console.table(porVendedor.slice(0, 3))
+
+    console.log('[3] listarPorMesEValor("2026-01", 500)')
+    const filtradas = await repo.listarPorMesEValor('2026-01', 500)
+    console.log(`    → ${filtradas.length} registros retornados`)
+    console.table(filtradas.slice(0, 3))
+
+    console.log('[5] Semantic Layer — listarProdutoPorNomeProduto(Produto A)')
+    const produto = await repo.listarProdutoPorNomeProduto('Produto A')
+    console.log(`    → ${produto.length} registros retornados`)
+    console.table(produto.slice(0, 3))
+
+    console.log('[6] Semantic Layer — ranking de vendas via Raw sql')
+    const vendas = await ctx.table('vendas')
+    console.log(`    → schema detectado: [${vendas.columnNames.join(', ')}]`)
+
+  } catch (err: any) {
+    console.error('\n[ERRO]', err.message)
+    console.error('Verifique se o PostgreSQL está rodando e se a tabela "vendas" existe.')
+  } finally {
+    await executor.close()
+    console.log('\n── Conexão encerrada ──────────────────────────────\n')
+  }
+}
+
+main()

--- a/src/usecases/rawSqlEQueryBuilderBenchmarking.ts
+++ b/src/usecases/rawSqlEQueryBuilderBenchmarking.ts
@@ -1,0 +1,553 @@
+import { PgAdapter } from '@infrastructure/adapters/PgAdapter.js'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import { RawSql } from '@core/decorators/RawSql.js' 
+import type { IQueryExecutor } from '@core/interfaces/IQueryExecutor.js' 
+import { WindowFnExprBuilder } from '@builders/relational/WindowFnExprBuilder.js'
+import { AggExprBuilder } from '@builders/relational/AggExprBuilder.js' 
+import { ColumnRef } from '@core/ColumnRef.js' 
+import { SqlGenerator } from '@codegen/SqlGenerator.js'
+import { TypedColumn } from '@semantic/TypedColumn.js'
+import 'dotenv/config'
+
+export const avg = (col: string | TypedColumn | AggExprBuilder) => {
+  if (col instanceof AggExprBuilder) {
+
+    return new AggExprBuilder('AVG', col.build() as any)
+  }
+  if (col instanceof TypedColumn) {
+
+    return new AggExprBuilder('AVG', col.ref)
+  }
+  return new AggExprBuilder('AVG', new ColumnRef(col, 'number'))
+}
+
+const rank = () =>
+  new WindowFnExprBuilder('RANK')
+
+const avgOver = (col: string) =>
+  new AggExprBuilder('AVG', new ColumnRef(col, 'number'))
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+// ─── Tipos de resultado ───────────────────────────────────────────────────────
+
+interface RankingVendas {
+  vendedor_id: number
+  mes: string
+  total_vendas: number
+  ranking: number
+}
+
+interface ComparacaoTemporal {
+  vendedor_id: number
+  mes: string
+  total_vendas: number
+  mes_anterior: number | null
+  variacao_absoluta: number | null
+}
+
+interface MediaMovel {
+  mes: string
+  total_vendas: number
+  media_movel_3m: number
+}
+
+interface RankingComJoin {
+  nome_vendedor: string
+  mes: string
+  total_vendas:number
+  ranking_regional: number
+  regiao: string
+}
+
+// ─── Repositório Raw SQL ──────────────────────────────────────────────────────
+// Abordagem tradicional: strings SQL nativas, sem type-safety de colunas
+
+class VendasRawRepository {
+  constructor(readonly executor: IQueryExecutor) {}
+
+  // CASO 1 — Ranking de vendedores por mês
+  @RawSql(`
+    SELECT
+      vendedor_id,
+      mes,
+      SUM(total) AS total_vendas,
+      RANK() OVER (
+        PARTITION BY mes
+        ORDER BY SUM(total) DESC
+      ) AS ranking
+    FROM vendas
+    GROUP BY vendedor_id, mes
+    ORDER BY mes, ranking
+  `)
+  async rankingPorMes(): Promise<RankingVendas[]> { return [] }
+
+  // CASO 2 — Comparação com mês anterior (LAG)
+  @RawSql(`
+    WITH vendas_mensais AS (
+      SELECT
+        vendedor_id,
+        mes,
+        SUM(total) AS total_vendas
+      FROM vendas
+      GROUP BY vendedor_id, mes
+    )
+    SELECT
+      vendedor_id,
+      mes,
+      total_vendas,
+      LAG(total_vendas, 1) OVER (
+        PARTITION BY vendedor_id
+        ORDER BY mes
+      )                                        AS mes_anterior,
+      total_vendas - LAG(total_vendas, 1) OVER (
+        PARTITION BY vendedor_id
+        ORDER BY mes
+      )                                        AS variacao_absoluta
+    FROM vendas_mensais
+    ORDER BY vendedor_id, mes
+  `)
+  async comparacaoMesAnterior(): Promise<ComparacaoTemporal[]> { return [] }
+
+  // CASO 3 — Média móvel de 3 meses
+  @RawSql(`
+    WITH vendas_mensais AS (
+      SELECT
+        mes,
+        SUM(total) AS total_vendas
+      FROM vendas
+      GROUP BY mes
+    )
+    SELECT
+      mes,
+      total_vendas,
+      ROUND(
+        AVG(total_vendas) OVER (
+          ORDER BY mes
+          ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+        ), 2
+      )                                        AS media_movel_3m
+    FROM vendas_mensais
+    ORDER BY mes
+  `)
+  async mediaMovel3Meses(): Promise<MediaMovel[]> { return [] }
+
+  // CASO 4 — Ranking regional com JOIN
+  @RawSql(`
+    SELECT
+      v.nome                                   AS nome_vendedor,
+      vd.mes,
+      SUM(vd.total)                            AS total_vendas,
+      RANK() OVER (
+        PARTITION BY v.regiao, vd.mes
+        ORDER BY SUM(vd.total) DESC
+      )                                        AS ranking_regional,
+      v.regiao
+    FROM vendas vd
+    INNER JOIN vendedores v ON vd.vendedor_id = v.id
+    GROUP BY v.nome, vd.mes, v.regiao
+    ORDER BY vd.mes, v.regiao, ranking_regional
+  `)
+  async rankingRegionalComJoin(): Promise<RankingComJoin[]> { return [] }
+}
+
+// ─── Helpers de log ───────────────────────────────────────────────────────────
+
+const linha  = (char = '─', n = 60) => char.repeat(n)
+const titulo = (label: string) => {
+  console.log('\n' + linha('═'))
+  console.log(`  ${label}`)
+  console.log(linha('═'))
+}
+const caso = (n: number, label: string, abordagem: 'RAW SQL' | 'BEIJU') => {
+  const emoji = abordagem === 'RAW SQL' ? '🔴' : '🟢'
+  console.log(`\n${emoji}  CASO ${n} [${abordagem}] — ${label}`)
+  console.log(linha())
+}
+const tempo = (ms: number) =>
+  `  ⏱  Executado em ${ms}ms`
+
+const printResultado = (rows: any[], max = 4) => {
+  if (rows.length === 0) {
+    console.log('  → Nenhum resultado.')
+    return
+  }
+  console.log(`  → ${rows.length} linhas retornadas:`)
+  console.table(rows.slice(0, max))
+  if (rows.length > max) {
+    console.log(`  ... e mais ${rows.length - max} linhas`)
+  }
+}
+
+// ─── MAIN ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const executor = PgAdapter.getInstance(CONNECTION_STRING)
+  const rawRepo = new VendasRawRepository(executor)
+  const ctx = new AnalyticsContext(CONNECTION_STRING)
+
+  
+
+  titulo('Beiju — Estudo de Caso Comparativo')
+  console.log('  Raw SQL vs Query Builder com Semantic Layer')
+  console.log('  4 consultas analíticas, 2 abordagens cada')
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // CASO 1 — Ranking de vendedores por mês
+  // ══════════════════════════════════════════════════════════════════════════
+
+  caso(1, 'Ranking de vendedores por mês', 'RAW SQL')
+  console.log(`
+  SQL EXECUTADO:
+  ┌────────────────────────────────────────────────────────┐
+  │  SELECT vendedor_id, mes,                              │
+  │    SUM(total) AS total_vendas,                         │
+  │    RANK() OVER (                                       │
+  │      PARTITION BY mes ORDER BY SUM(total) DESC         │
+  │    ) AS ranking                                        │
+  │  FROM vendas                                           │
+  │  GROUP BY vendedor_id, mes ORDER BY mes, ranking       │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código SQL: 8 | Strings literais: SIM | Type-safe: NÃO`)
+
+  let t0 = Date.now()
+  const r1Raw = await rawRepo.rankingPorMes()
+  console.log(tempo(Date.now() - t0))
+  printResultado(r1Raw)
+
+  caso(1, 'Ranking de vendedores por mês', 'BEIJU')
+  console.log(`
+  CÓDIGO BEIJU:
+  ┌────────────────────────────────────────────────────────┐
+  │  const vendas = await ctx.table('vendas')              │
+  │                                                        │
+  │  await vendas                                          │
+  │    .select([                                           │
+  │      vendas.vendedor_id,                               │
+  │      vendas.mes,                                       │
+  │      vendas.total.sum().as('total_vendas'),            │
+  │      rank()                                            │
+  │        .over(w => w                                    │
+  │          .partitionBy('mes')                           │
+  │          .orderBy('total', 'DESC'))                    │
+  │        .as('ranking'),                                 │
+  │    ])                                                  │
+  │    .groupBy(vendas.vendedor_id, vendas.mes)            │
+  │    .orderBy(vendas.mes)                                │
+  │    .fetch()                                            │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código: 13 | Strings literais: NÃO | Type-safe: SIM`)
+
+  const vendas = await ctx.table('vendas')
+
+  const { rank,lag } = await import('./../index.js') 
+
+    t0 = Date.now()
+
+  
+  const r1Beiju = await vendas
+    .select([
+      vendas.vendedor_id,
+      vendas.mes,
+      (vendas.total).sum().as('total_vendas'),
+      rank()
+        .over(w => w.partitionBy('mes').orderBy(vendas.total.sum(), 'DESC'))
+        .as('ranking'),
+    ])
+    .groupBy(
+      vendas.vendedor_id,
+      vendas.mes,
+    )
+    .orderBy(vendas.mes)
+    .fetch()
+
+  console.log(tempo(Date.now() - t0))
+  printResultado(r1Beiju)
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // CASO 2 — Comparação com mês anterior (LAG)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  caso(2, 'Comparação com período anterior — LAG()', 'RAW SQL')
+  console.log(`
+  SQL EXECUTADO:
+  ┌────────────────────────────────────────────────────────┐
+  │  WITH vendas_mensais AS (                              │
+  │    SELECT vendedor_id, mes, SUM(total) AS total_vendas │
+  │    FROM vendas GROUP BY vendedor_id, mes               │
+  │  )                                                     │
+  │  SELECT vendedor_id, mes, total_vendas,                │
+  │    LAG(total_vendas, 1) OVER (                         │
+  │      PARTITION BY vendedor_id ORDER BY mes             │
+  │    ) AS mes_anterior,                                  │
+  │    total_vendas - LAG(total_vendas,1) OVER (           │
+  │      PARTITION BY vendedor_id ORDER BY mes             │
+  │    ) AS variacao_absoluta                              │
+  │  FROM vendas_mensais ORDER BY vendedor_id, mes         │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código SQL: 14 | Strings literais: SIM | Type-safe: NÃO`)
+
+  t0 = Date.now()
+  const r2Raw = await rawRepo.comparacaoMesAnterior()
+  console.log(tempo(Date.now() - t0))
+  printResultado(r2Raw)
+
+  caso(2, 'Comparação com período anterior — LAG()', 'BEIJU')
+  console.log(`
+  CÓDIGO BEIJU:
+  ┌────────────────────────────────────────────────────────┐
+  │  await vendas                                          │
+  │    .select([                                           │
+  │      vendas.vendedor_id,                               │
+  │      vendas.mes,                                       │
+  │      vendas.total.sum().as('total_vendas'),            │
+  │      lag('total', 1)                                   │
+  │        .over(w => w                                    │
+  │          .partitionBy('vendedor_id')                   │
+  │          .orderBy('mes'))                              │
+  │        .as('mes_anterior'),                            │
+  │    ])                                                  │
+  │    .groupBy(vendas.vendedor_id, vendas.mes)            │
+  │    .orderBy(vendas.vendedor_id, vendas.mes)            │
+  │    .fetch()                                            │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código: 12 | Strings literais: NÃO | Type-safe: SIM`)
+
+  t0 = Date.now()
+  const r2Beiju = await vendas
+    .select([
+      vendas.vendedor_id,
+      vendas.mes,
+      (vendas.total).sum().as('total_vendas'),
+      lag(vendas.total.sum(), 1)
+        .over(w => w.partitionBy('vendedor_id').orderBy('mes'))
+        .as('mes_anterior'),
+    ])
+    .groupBy(
+      vendas.vendedor_id,
+      vendas.mes,
+    )
+    .orderBy(vendas.vendedor_id)
+    .fetch()
+
+  console.log(tempo(Date.now() - t0))
+  printResultado(r2Beiju)
+  
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // CASO 3 — Média móvel de 3 meses
+  // ══════════════════════════════════════════════════════════════════════════
+
+  caso(3, 'Média móvel de 3 meses — AVG() OVER ROWS BETWEEN', 'RAW SQL')
+  console.log(`
+  SQL EXECUTADO:
+  ┌────────────────────────────────────────────────────────┐
+  │  WITH vendas_mensais AS (                              │
+  │    SELECT mes, SUM(total) AS total_vendas              │
+  │    FROM vendas GROUP BY mes                            │
+  │  )                                                     │
+  │  SELECT mes, total_vendas,                             │
+  │    ROUND(                                              │
+  │      AVG(total_vendas) OVER (                          │
+  │        ORDER BY mes                                    │
+  │        ROWS BETWEEN 2 PRECEDING AND CURRENT ROW        │
+  │      ), 2                                              │
+  │    ) AS media_movel_3m                                 │
+  │  FROM vendas_mensais ORDER BY mes                      │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código SQL: 13 | Strings literais: SIM | Type-safe: NÃO`)
+
+  t0 = Date.now()
+  const r3Raw = await rawRepo.mediaMovel3Meses()
+  console.log(tempo(Date.now() - t0))
+  printResultado(r3Raw)
+
+  caso(3, 'Média móvel de 3 meses — AVG() OVER ROWS BETWEEN', 'BEIJU')
+  console.log(`
+  CÓDIGO BEIJU:
+  ┌────────────────────────────────────────────────────────┐
+  │  await vendas                                          │
+  │    .select([                                           │
+  │      vendas.mes,                                       │
+  │      vendas.total.sum().as('total_vendas'),            │
+  │      vendas.total.avg()                                │
+  │        .over(w => w                                    │
+  │          .orderBy('mes')                               │
+  │          .rowsBetween(-2, 'current'))                  │
+  │        .as('media_movel_3m'),                          │
+  │    ])                                                  │
+  │    .groupBy(vendas.mes)                                │
+  │    .orderBy(vendas.mes)                                │
+  │    .fetch()                                            │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código: 12 | Strings literais: NÃO | Type-safe: SIM`)
+
+
+  t0 = Date.now();
+
+ const query3 = vendas
+  .select([
+    vendas.mes,
+    (vendas.total).sum().as('total_vendas'),
+    avg(vendas.total.sum())
+      .over(w => w.orderBy('mes').rowsBetween(-2, 'current'))
+      .as('media_movel_3m'),
+  ])
+  .groupBy(vendas.mes)
+  .orderBy(vendas.mes)
+
+  // Debug — inspeciona o SQL antes de executar
+  const { sql, params } = SqlGenerator.compile((query3 as any).build());
+  console.log("\n[DEBUG SQL CASO 3]\n", sql);
+  console.log("[DEBUG PARAMS]", params);
+
+  const r3Beiju = await query3.fetch();
+
+  console.log(tempo(Date.now() - t0));
+  printResultado(r3Beiju);
+  // ══════════════════════════════════════════════════════════════════════════
+  // CASO 4 — Ranking regional com INNER JOIN
+  // ══════════════════════════════════════════════════════════════════════════
+
+  caso(4, 'Ranking regional com INNER JOIN', 'RAW SQL')
+  console.log(`
+  SQL EXECUTADO:
+  ┌────────────────────────────────────────────────────────┐
+  │  SELECT v.nome AS nome_vendedor, vd.mes,               │
+  │    SUM(vd.total) AS total_vendas,                      │
+  │    RANK() OVER (                                       │
+  │      PARTITION BY v.regiao, vd.mes                     │
+  │      ORDER BY SUM(vd.total) DESC                       │
+  │    ) AS ranking_regional,                              │
+  │    v.regiao                                            │
+  │  FROM vendas vd                                        │
+  │  INNER JOIN vendedores v ON vd.vendedor_id = v.id      │
+  │  GROUP BY v.nome, vd.mes, v.regiao                     │
+  │  ORDER BY vd.mes, v.regiao, ranking_regional           │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código SQL: 11 | Strings literais: SIM | Type-safe: NÃO`)
+
+  t0 = Date.now()
+  const r4Raw = await rawRepo.rankingRegionalComJoin()
+  console.log(tempo(Date.now() - t0))
+  printResultado(r4Raw)
+
+  caso(4, 'Ranking regional com INNER JOIN', 'BEIJU')
+  console.log(`
+  CÓDIGO BEIJU:
+  ┌────────────────────────────────────────────────────────┐
+  │  const vendedores = await ctx.table('vendedores')      │
+  │                                                        │
+  │  await vendas                                          │
+  │    .select([                                           │
+  │      vendedores.nome.as('nome_vendedor'),              │
+  │      vendas.mes,                                       │
+  │      vendas.total.sum().as('total_vendas'),            │
+  │      rank()                                            │
+  │        .over(w => w                                    │
+  │          .partitionBy('regiao', 'mes')                 │
+  │          .orderBy('total', 'DESC'))                    │
+  │        .as('ranking_regional'),                        │
+  │      vendedores.regiao,                                │
+  │    ])                                                  │
+  │    .innerJoin(vendedores)                              │
+  │      .on(vendas.vendedor_id, vendedores.id)            │
+  │    .groupBy(                                           │
+  │      vendedores.nome,                                  │
+  │      vendas.mes,                                       │
+  │      vendedores.regiao,                                │
+  │    )                                                   │
+  │    .orderBy(vendas.mes)                                │
+  │    .fetch()                                            │
+  └────────────────────────────────────────────────────────┘
+  Linhas de código: 22 | Strings literais: NÃO | Type-safe: SIM`)
+
+  t0 = Date.now()
+  const vendedores = await ctx.table('vendedores')
+
+  const r4Beiju = await vendas
+    .select([
+      (vendedores.nome).as('nome_vendedor'),
+      vendas.mes,
+      (vendas.total).sum().as('total_vendas'),
+      rank()
+        .over(w => w
+          .partitionBy('regiao' ,'mes')
+          .orderBy(vendas.total.sum(), 'DESC'))
+        .as('ranking_regional'),
+      vendedores.regiao,
+    ])
+    .innerJoin(vendedores)
+      .on(vendas.vendedor_id, vendedores.id)
+    .groupBy(
+      vendedores.nome,
+      vendas.mes,
+      vendedores.regiao,
+    )
+    .orderBy(vendas.mes)
+    .fetch()
+
+  console.log(tempo(Date.now() - t0))
+  printResultado(r4Beiju)
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SUMÁRIO COMPARATIVO
+  // ══════════════════════════════════════════════════════════════════════════
+
+  titulo('Sumário Comparativo')
+  console.table([
+    {
+      Caso:             '1 — Ranking por mês',
+      'Raw SQL (linhas)': 8,
+      'Beiju (linhas)':  13,
+      'Strings literais Raw': 'SIM',
+      'Strings literais Beiju': 'NÃO',
+      'Type-safe Raw': 'NÃO',
+      'Type-safe Beiju': 'SIM',
+    },
+    {
+      Caso:             '2 — LAG / período anterior',
+      'Raw SQL (linhas)': 14,
+      'Beiju (linhas)':  12,
+      'Strings literais Raw': 'SIM',
+      'Strings literais Beiju': 'NÃO',
+      'Type-safe Raw': 'NÃO',
+      'Type-safe Beiju': 'SIM',
+    },
+    {
+      Caso:             '3 — Média móvel 3m',
+      'Raw SQL (linhas)': 13,
+      'Beiju (linhas)':  12,
+      'Strings literais Raw': 'SIM',
+      'Strings literais Beiju': 'NÃO',
+      'Type-safe Raw': 'NÃO',
+      'Type-safe Beiju': 'SIM',
+    },
+    {
+      Caso:             '4 — JOIN + Ranking regional',
+      'Raw SQL (linhas)': 11,
+      'Beiju (linhas)':  22,
+      'Strings literais Raw': 'SIM',
+      'Strings literais Beiju': 'NÃO',
+      'Type-safe Raw': 'NÃO',
+      'Type-safe Beiju': 'SIM',
+    },
+  ])
+
+  console.log(`
+  Observações:
+  • Em Raw SQL, erros de coluna só aparecem em RUNTIME (no banco)
+  • No Beiju, erros de coluna são capturados em COMPILE-TIME (TypeScript)
+  • O Caso 4 com JOIN tem mais linhas no Beiju — mas todas com autocomplete
+  • Raw SQL não permite refatoração segura de nomes de colunas
+  • O Beiju permite trocar o adapter (PostgreSQL → CSV) sem alterar a query
+  `)
+
+  await executor.close()
+  console.log(linha('─'))
+  console.log('  Conexão encerrada.')
+  console.log(linha('─') + '\n')
+}
+
+
+main().catch(console.error)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "strict": true,
+    "strict": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
@@ -18,7 +18,9 @@
       "@codegen/*":        ["./src/codegen/*"],
       "@semantic/*":       ["./src/semantic/*"],
       "@infrastructure/*": ["./src/infrastructure/*"]
-    }
+    },
+  "experimentalDecorators": true,
+  "emitDecoratorMetadata": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { resolve } from 'path'
 
+export default defineConfig({
   cacheDir: "./node_modules/.vitest",
   plugins: [tsconfigPaths()],
   test: {
@@ -9,7 +10,6 @@ import { resolve } from 'path'
     exclude: ["node_modules", "dist"],
     environment: "node",
     isolate: true,
-   
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'vitest/config'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { resolve } from 'path'
 
-export default defineConfig({
-  cacheDir: "./node_modules/",
+  cacheDir: "./node_modules/.vitest",
   plugins: [tsconfigPaths()],
   test: {
     include: ["src/test/**/*.test.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,24 @@
 import { defineConfig } from 'vitest/config'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import { resolve } from 'path'
 
 export default defineConfig({
+  cacheDir: "./node_modules/",
   plugins: [tsconfigPaths()],
   test: {
-    globals: true,
-    environment: 'node',
+    include: ["src/test/**/*.test.ts"],
+    exclude: ["node_modules", "dist"],
+    environment: "node",
+    isolate: true,
+   
   },
-})
+  resolve: {
+    alias: {
+      "@core": resolve(__dirname, "./src/core"),
+      "@builders": resolve(__dirname, "./src/builders"),
+      "@semantic": resolve(__dirname, "./src/semantic"),
+      "@infrastructure": resolve(__dirname, "./src/infrastructure"),
+      "@codegen": resolve(__dirname, "./src/codegen"),
+    },
+  },
+});


### PR DESCRIPTION
## Descrição do problema

Essa tarefa tem o objetivo simples: Criar um decorator personalizado que contenha  regras imbutidas capaz de ativar o modo rawquey. O modo rawquery, no contexto do beiju será criado para casos específicos que o usuário pretende usar query nativa em vez do query builder. Não é uma forma de canibalização porque a query nativa pode se integrar ao query builder.
## Solução proposta

Foi criado um decorator que usasse o conceito de queryNative junto ao código e que fosse capaz de não tornar a consulta vulnerável a SQL injection. 
Precisei criar o novo decorator e adpatar classes existentes como SQLGenerator, criar um novo método executorRaw...
- Se tornou mais fácil a implementação porque o @RawSql não precisa passar por camadas de abstração usadas nos métodos do queryBuilder Beiju, como a SemanticLayer e BuilderLayer.

- Também foi necessário realizar manutenções no sistema para que as consultas de exemplo e consultas comparaticas retornassem o valor esperado. Consultas com agregação não estavam sendo detectadas corretamente.

## Como testar

 - Foi criado um arquivo de teste via vitest para testar os principais cenários que consiste o decorator @RawSql. Rode o teste e veja o log do vitest passar com êxito. 
 - Para um melhor entendimento, faça as consultas por si próprio ou rode o arquivo rawSqlBase com os demonstrativos de SQL nativo via decorator.
 
## Resultados

Agora o usuário do Beiju poderá escolher entre usar a abordagem estabelecida pelo query builder (abstração de querys no contexto analítico/identificação de erros em compileTime) ou usar o decorator @RawSql a partir da necessidade de migrar querys existentes ecriar querys memorizadas.  

Geral:
- [x] Você revisou seu próprio código?
- [x] Lembrou de não deixar nenhuma linha de código comentado?
- [x] Build está passando?
- [x] Fez testes?