### PR TITLE
BJU-006 | Gerar implementação de teste manual de operadores (neq, gt, lt, gte, lte, between, in)

### DIFF
--- a/src/test/integration/semantic/WhereOperators.test.ts
+++ b/src/test/integration/semantic/WhereOperators.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import 'dotenv/config'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+describe('WHERE operators — integração com PostgreSQL real', () => {
+  let ctx: AnalyticsContext
+  let vendas: Awaited<ReturnType<AnalyticsContext['table']>>
+
+  beforeAll(async () => {
+    ctx = new AnalyticsContext(CONNECTION_STRING)
+    vendas = await ctx.table('vendas')
+  })
+
+  afterAll(async () => {
+    await (ctx as any).adapter.close()
+  })
+
+  it('neq — exclui registros com valor igual', async () => {
+    const result = await vendas
+      .select([vendas.id, vendas.vendedor_id])
+      .where((vendas.vendedor_id).neq(1))
+      .fetch<{ id: number; vendedor_id: number }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => r.vendedor_id !== 1)).toBe(true)
+  })
+
+  it('gt — retorna apenas valores maiores que o limite', async () => {
+    const result = await vendas
+      .select([vendas.id, vendas.total])
+      .where((vendas.total).gt(1000))
+      .fetch<{ id: number; total: string }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => Number(r.total) > 1000)).toBe(true)
+  })
+
+  it('lt — retorna apenas valores menores que o limite', async () => {
+    const result = await vendas
+      .select([vendas.id, vendas.total])
+      .where((vendas.total).lt(1000))
+      .fetch<{ id: number; total: string }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => Number(r.total) < 1000)).toBe(true)
+  })
+
+  it('gte — inclui o valor-limite na comparação', async () => {
+    const result = await vendas
+      .select([vendas.id , vendas.total ])
+      .where((vendas.total ).gte(1200))
+      .fetch<{ id: number; total: string }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => Number(r.total) >= 1200)).toBe(true)
+  })
+
+  it('lte — inclui o valor-limite na comparação', async () => {
+    const result = await vendas
+      .select([vendas.id , vendas.total ])
+      .where((vendas.total ).lte(850))
+      .fetch<{ id: number; total: string }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => Number(r.total) <= 850)).toBe(true)
+  })
+
+  it('between — retorna valores dentro do intervalo inclusivo', async () => {
+    const result = await vendas
+      .select([vendas.id , vendas.total ])
+      .where((vendas.total ).between(800, 2000))
+      .fetch<{ id: number; total: string }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(
+      result.every(r => Number(r.total) >= 800 && Number(r.total) <= 2000)
+    ).toBe(true)
+  })
+
+  it('in — retorna apenas os registros cujo valor está na lista', async () => {
+    const result = await vendas
+      .select([vendas.id, vendas.vendedor_id])
+      .where((vendas.vendedor_id).in([1, 3]))
+      .fetch<{ id: number; vendedor_id: number }>()
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.every(r => [1, 3].includes(r.vendedor_id))).toBe(true)
+  })
+
+  it('in — lança erro de SQL se a lista estiver vazia', async () => {
+    await expect(
+      vendas
+        .select([vendas.id])
+        .where((vendas.vendedor_id).in([]))
+        .fetch()
+    ).rejects.toThrow('IN operator requires a non-empty array value')
+  })
+})


### PR DESCRIPTION
## Descrição do problema

Adicionar testes que antes não estavam cobertos aos operadores lógicos necessários para o uso básico do querybuilder. 

Contexto:

Esses operadores já têm implementação no WhereColumnRef (camada relacional) e são herdados pelo TypedColumn (semantic layer) via eq/neq/gt/lt/gte/lte/between/in. Mas até agora só .eq() foi exercitado contra banco real nos casos de benchmark. Os outros seis nunca rodaram uma query de verdade — só existem testes unitários com mock, que não capturam erros de geração de SQL (como os que apareceram nos JOINs e Window Functions).

## Solução proposta

- Foi criada uma nova pasta em test -> integration, que contém o novo arquivo de testes WhereOperators.test.ts e testa os principais operadores lógicos via vitest.

 
## Como testar

Baixe o projeto Beiju em sua máquina, rode algum usecase padrão e depois rode o comando: 

```
npm run test src/test/integration/semantic/WhereOperators.test.ts
```

## Resultados

Os 8 testes cobertos passam tranquilamente e aborda um cenário importante para uma utilização mais adequada do beiju.
