### PR TITLE
BJU-007 | .fullOuterJoin() — completar a cobertura de JOINs já modelada na AST

### DIFF
--- a/src/builders/relational/JoinBuilder.ts
+++ b/src/builders/relational/JoinBuilder.ts
@@ -23,23 +23,11 @@ export class JoinBuilder<TBuilder> {
     private readonly joinType?:   JoinType,
   ) {}
 
-  /**
-   * Define o alias SQL da tabela joined.
-   * Exemplo: .innerJoin(usuarios).as('u').on(vendas.usuario_id, ...)
-   */
   as(alias: string): this {
     this.aliasValue = alias
     return this
   }
 
-  /**
-   * Define a condição ON e finaliza o JOIN,
-   * devolvendo o builder pai para encadeamento.
-   *
-   * Suporta múltiplas condições:
-   *   .on(vendas.usuario_id, usuarios.id)
-   *   .on(vendas.regiao_id,  usuarios.regiao_id) ← segunda condição AND
-   */
   on(left: TypedColumn, right: TypedColumn): TBuilder {
     this.conditions.push(new JoinCondition(left.ref, right.ref))
     

--- a/src/builders/semantic/SemanticSelectBuilder.ts
+++ b/src/builders/semantic/SemanticSelectBuilder.ts
@@ -87,6 +87,9 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
   return new JoinBuilder(table, (spec) => this.addJoin(spec), 'RIGHT')
   }
 
+  fullOuterJoin(table: Table): JoinBuilder<this> {
+  return new JoinBuilder(table,(spec) => this.addJoin(spec), 'FULL OUTER',)
+  }
 
   private resolveSelections(): SelectQuery['select'] {
     return this.selections.map(item => {

--- a/src/builders/semantic/SemanticSelectBuilder.ts
+++ b/src/builders/semantic/SemanticSelectBuilder.ts
@@ -26,30 +26,6 @@ export type WhereInput =
   | WhereCondition[]
   | WhereClause
 
-/**
- * Builder de consultas analíticas orientado a semântica.
- * Construído sobre o SelectQuery e SqlGenerator existentes,
- * mas expõe uma API onde colunas são objetos, não strings.
- *
- * Criado internamente pelo Table.select() — não instancie diretamente.
- *
- * Exemplo:
- *   const orders = await ctx.table('orders')
- *
- *   const result = await orders
- *     .select([
- *       orders.seller_name,
- *       orders.total_amount.sum().as('total_vendas'),
- *       rank()
- *         .over(w => w.orderBy(orders.total_amount.name, 'DESC'))
- *         .as('ranking'),
- *     ])
- *     .where(orders.month.eq('2026-01'))
- *     .groupBy(orders.seller_name)
- *     .orderBy(orders.total_amount, 'DESC')
- *     .limit(10)
- *     .fetch()
- */
 export class SemanticSelectBuilder implements ISemanticSelectBuilder {
   private whereInput?: WhereInput
   private groupByColumns: ColumnRef[] = []
@@ -120,10 +96,6 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
     })
   }
 
-  /**
-   * Resolve o WhereInput para WhereClause da AST.
-   * Aceita condição única, array de condições ou WhereClause direta.
-   */
   private resolveWhere(): SelectQuery['where'] {
     if (!this.whereInput) return undefined
 

--- a/src/codegen/SqlGenerator.ts
+++ b/src/codegen/SqlGenerator.ts
@@ -227,10 +227,6 @@ export class SqlGenerator {
       )
       .join(" AND ");
 
-    const returnJoin = join.type
-      ? `${join.type} JOIN ${tableRef} ON ${conditions}`
-      : `JOIN ${tableRef} ON ${conditions}`;
-
-    return returnJoin;
+      return `${join.type} JOIN ${tableRef} ON ${conditions}`
   }
 }

--- a/src/core/ast/JoinSpec.ts
+++ b/src/core/ast/JoinSpec.ts
@@ -1,11 +1,7 @@
 import { ColumnRef } from '../ColumnRef.js'
 
-export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'JOIN';
+export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'JOIN' | 'FULL OUTER';
 
-/**
- * Condição atômica de junção.
- * Representa: tabela_a.coluna = tabela_b.coluna
- */
 export class JoinCondition {
   constructor(
     readonly left:  ColumnRef,

--- a/src/core/interfaces/ISemanticSelectBuilder.ts
+++ b/src/core/interfaces/ISemanticSelectBuilder.ts
@@ -2,11 +2,6 @@ import { JoinBuilder } from "@builders/relational/JoinBuilder.js"
 import { Table } from "@semantic/Table.js"
 import { SelectQuery } from "@core/ast/clause/SelectQuery.js"
 
-/**
- * Contrato mínimo do SemanticSelectBuilder.
- * Usado como tipo de retorno da SelectBuilderFactory em Table.ts
- * para evitar importação circular de SemanticSelectBuilder.
- */
 export interface ISemanticSelectBuilder {
   fetch<T>(): Promise<T[]>
   build(): SelectQuery 
@@ -19,4 +14,5 @@ export interface ISemanticSelectBuilder {
   innerJoin(table: Table): JoinBuilder<this>
   leftJoin(table: Table): JoinBuilder<this>
   rightJoin(table: Table): JoinBuilder<this>
+  fullOuterJoin(table: Table): JoinBuilder<this> 
 }

--- a/src/test/integration/semantic/FullOuterJoin.test.ts
+++ b/src/test/integration/semantic/FullOuterJoin.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import type { TypedColumn } from '@semantic/TypedColumn.js'
+import 'dotenv/config'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+describe('FULL OUTER JOIN — integração com PostgreSQL real', () => {
+  let ctx: AnalyticsContext
+  let vendas: Awaited<ReturnType<AnalyticsContext['table']>>
+  let vendedores: Awaited<ReturnType<AnalyticsContext['table']>>
+
+  beforeAll(async () => {
+    ctx = new AnalyticsContext(CONNECTION_STRING)
+    vendas = await ctx.table('vendas')
+    vendedores = await ctx.table('vendedores')
+  })
+
+  afterAll(async () => {
+    await (ctx as any).adapter.close()
+  })
+
+  it('gera SQL com FULL OUTER JOIN', async () => {
+    const result = await vendas
+      .select([
+        (vendas.id),
+        (vendedores.nome),
+      ])
+      .fullOuterJoin(vendedores).on(
+        vendas.vendedor_id ,
+        vendedores.id,
+      )
+      .fetch()
+
+    expect(Array.isArray(result)).toBe(true)
+  })
+
+  it('retorna vendedores sem vendas e vendas sem vendedor correspondente', async () => {
+    // Insere um vendedor sem vendas associadas, para validar o lado direito do OUTER
+      const adapter = (ctx as any).adapter
+
+      await adapter.executeRaw(
+      `SELECT setval('vendedores_id_seq', COALESCE((SELECT MAX(id) FROM vendedores), 1))`
+      )
+
+      await adapter.executeRaw(
+    `DELETE FROM vendedores WHERE nome = $1`,
+    ['Vendedor Sem Vendas']
+    )
+
+    await adapter.executeRaw(
+        `INSERT INTO vendedores (nome, regiao) VALUES ($1, $2)`,
+        ['Vendedor Sem Vendas', 'Centro-Oeste']
+    )
+
+    const result = await vendas
+      .select([
+        (vendas.id),
+        (vendedores.nome),
+      ])
+      .fullOuterJoin(vendedores).on(
+        vendas.vendedor_id,
+        vendedores.id,
+      )
+      .fetch<{ id: number | null; nome: string | null }>()
+
+    const semVendas = result.some(r => r.id === null && r.nome === 'Vendedor Sem Vendas')
+    expect(semVendas).toBe(true)
+  })
+
+  it('SQL gerado contém a cláusula FULL OUTER JOIN', async () => {
+    const builder = vendas
+      .select([(vendas.id)])
+      .fullOuterJoin(vendedores).on(
+        vendas.vendedor_id,
+        vendedores.id,
+      )
+
+    const { sql } = (builder as any).build
+      ? (await import('@codegen/SqlGenerator.js')).SqlGenerator.compile((builder as any).build())
+      : { sql: '' }
+
+    expect(sql).toContain('FULL OUTER JOIN vendedores')
+  })
+})


### PR DESCRIPTION
## Descrição do problema

Cria método .fullOuterJoin() para completar cobertura de métodos JOIN.

## Solução proposta

implementa método .fullOuterJoin(), altera types especifico, adiciona simplificação em SQLGenerator e cria testes em ambiente de teste via vitest.

## Como testar

Baixe o projeto Beiju em sua máquina, rode algum usecase padrão e depois rode o comando: 

```
npm run test src/test/integration/semantic/FullOuterJoin.test.ts
```