### PR TITLE
BJU-009 | Criar tradução semantica como alias em portugues

### DIFF
--- a/src/builders/relational/AggExprBuilder.ts
+++ b/src/builders/relational/AggExprBuilder.ts
@@ -15,18 +15,27 @@ export class AggExprBuilder {
   ) {}
 
   as(alias: string): this {
-    this.alias = alias
-    return this
+    this.alias = alias;
+    return this;
   }
 
   over(fn: WindowBuilderFn): this {
-    const wb = new WindowBuilder()
-    fn(wb)
-    this.windowSpec = wb.build()
-    return this
+    const wb = new WindowBuilder();
+    fn(wb);
+    this.windowSpec = wb.build();
+    return this;
+  }
+
+  // ─── Alias em português —
+  como(alias: string): this {
+    return this.as(alias);
+  }
+
+  sobre(fn: WindowBuilderFn): this {
+    return this.over(fn);
   }
 
   build(): AggregateExpr {
-    return new AggregateExpr(this.fn, this.column, this.alias, this.windowSpec)
+    return new AggregateExpr(this.fn, this.column, this.alias, this.windowSpec);
   }
 }

--- a/src/builders/relational/JoinBuilder.ts
+++ b/src/builders/relational/JoinBuilder.ts
@@ -14,30 +14,40 @@ import type { Table }          from '../../semantic/Table.js'
  *   .leftJoin(tableProdutos).on(vendas.produto_id, tableProdutos.id)
  */
 export class JoinBuilder<TBuilder> {
-  private conditions: JoinCondition[] = []
-  private aliasValue?: string
+  private conditions: JoinCondition[] = [];
+  private aliasValue?: string;
 
   constructor(
-    private readonly joinTable:  Table,
+    private readonly joinTable: Table,
     private readonly onComplete: (spec: JoinSpec) => TBuilder,
-    private readonly joinType?:   JoinType,
+    private readonly joinType?: JoinType,
   ) {}
 
   as(alias: string): this {
-    this.aliasValue = alias
-    return this
+    this.aliasValue = alias;
+    return this;
   }
 
   on(left: TypedColumn, right: TypedColumn): TBuilder {
-    this.conditions.push(new JoinCondition(left.ref, right.ref))
-    
+    this.conditions.push(new JoinCondition(left.ref, right.ref));
+
     return this.onComplete(
       new JoinSpec(
         this.joinTable.tableName,
         this.conditions,
         this.joinType,
         this.aliasValue,
-      )
-    )
+      ),
+    );
+  }
+
+  // ─── Alias em português ──────────────────────────────────────────────────
+
+  como(alias: string): this {
+    return this.as(alias);
+  }
+
+  em(left: TypedColumn, right: TypedColumn): TBuilder {
+    return this.on(left, right);
   }
 }

--- a/src/builders/relational/SelectBuilder.ts
+++ b/src/builders/relational/SelectBuilder.ts
@@ -81,6 +81,11 @@ export class SelectBuilder implements ISelectBuilder {
     return this
   }
 
+   // ─── Alias em português  ─────────────────────────────────────
+    selecione(items: SelectFn): this {
+    return this.select(items)
+    }
+
   build(): SelectQuery {
     if (!this.fromClause) {
       throw new Error('SelectBuilder: .from() é obrigatório')

--- a/src/builders/relational/WindowBuilder.ts
+++ b/src/builders/relational/WindowBuilder.ts
@@ -4,37 +4,64 @@ import { WindowSpec } from '@core/ast/WindowSpec.js'
 import { OrderByItem } from '@core/ast/OrderByItem.js' 
 import { IWindowBuilder } from '@core/interfaces/IWindowBuilder.js' 
 import { AggExprBuilder } from './AggExprBuilder.js' 
+import { resolveOrderByExpr } from '@core/ast/OrderByItem.js'
 export type FrameBoundary = number | 'unbounded' | 'current'
 
 export type WindowBuilderFn = (w: WindowBuilder) => WindowBuilder
 
 export class WindowBuilder implements IWindowBuilder {
-  private partitionByColumns: ColumnRef[] = []
-  private orderByItems: OrderByItem[] = []
-  private frameSpec?: FrameSpec
+  private partitionByColumns: ColumnRef[] = [];
+  private orderByItems: OrderByItem[] = [];
+  private frameSpec?: FrameSpec;
 
   partitionBy(...columns: string[]): this {
-    this.partitionByColumns = columns.map(col => new ColumnRef(col, 'string'))
-    return this
+    this.partitionByColumns = columns.map(
+      (col) => new ColumnRef(col, "string"),
+    );
+    return this;
   }
 
-  orderBy(column: string | AggExprBuilder, direction: 'ASC' | 'DESC' = 'ASC'): this {
-    const expr = column instanceof AggExprBuilder
-    ? column.build()                          // AggregateExpr
-    : new ColumnRef(column, 'string')         // ColumnRef
+  orderBy(
+    column: string | AggExprBuilder,
+    direction: "ASC" | "DESC" = "ASC",
+  ): this {
+    const expr =
+      typeof column === "string"
+        ? new ColumnRef(column, "string")
+        : resolveOrderByExpr(column);
 
-  this.orderByItems.push(new OrderByItem(expr, direction))
-  return this
+    this.orderByItems.push(new OrderByItem(expr, direction));
+    return this;
   }
 
   rowsBetween(start: FrameBoundary, end: FrameBoundary): this {
-    this.frameSpec = new FrameSpec('ROWS', start, end)
-    return this
+    this.frameSpec = new FrameSpec("ROWS", start, end);
+    return this;
   }
 
   rangeBetween(start: FrameBoundary, end: FrameBoundary): this {
-    this.frameSpec = new FrameSpec('RANGE', start, end)
-    return this
+    this.frameSpec = new FrameSpec("RANGE", start, end);
+    return this;
+  }
+
+  // ─── Alias em português ──────────────────────────────────────────────────
+  particionePor(...columns: string[]): this {
+    return this.partitionBy(...columns);
+  }
+
+  ordenePor(
+    column: string | AggExprBuilder,
+    direction: "ASC" | "DESC" = "ASC",
+  ): this {
+    return this.orderBy(column, direction);
+  }
+
+  linhasEntre(start: FrameBoundary, end: FrameBoundary): this {
+    return this.rowsBetween(start, end);
+  }
+
+  faixaEntre(start: FrameBoundary, end: FrameBoundary): this {
+    return this.rangeBetween(start, end);
   }
 
   build(): WindowSpec {
@@ -42,6 +69,6 @@ export class WindowBuilder implements IWindowBuilder {
       this.partitionByColumns,
       this.orderByItems,
       this.frameSpec,
-    )
+    );
   }
 }

--- a/src/builders/relational/WindowFnExprBuilder.ts
+++ b/src/builders/relational/WindowFnExprBuilder.ts
@@ -28,6 +28,16 @@ export class WindowFnExprBuilder {
     return this
   }
 
+  // ─── Alias em português — em ambas as classes ─────────────────────────────
+  como(alias: string): this {
+    return this.as(alias)
+  }
+
+  // (em WindowFnExprBuilder também)
+  sobre(fn: WindowBuilderFn): this {
+    return this.over(fn)
+  }
+
   build(): WindowFunctionExpr {
     if (!this.windowSpec) {
       throw new Error(

--- a/src/builders/semantic/SemanticSelectBuilder.ts
+++ b/src/builders/semantic/SemanticSelectBuilder.ts
@@ -4,7 +4,7 @@ import type { WhereCondition } from '@core/ast/clause/WhereCondition.js'
 import { WhereClause } from '@core/ast/clause/WhereClause.js'
 import { SelectQuery } from '@core/ast/clause/SelectQuery.js' 
 import { ColumnRef } from '@core/ColumnRef.js' 
-import { OrderByItem } from '@core/ast/OrderByItem.js' 
+import { OrderByItem, resolveOrderByExpr} from '@core/ast/OrderByItem.js' 
 import { SqlGenerator } from '../../codegen/SqlGenerator.js' 
 import { AggExprBuilder } from '@builders/relational/AggExprBuilder.js' 
 import { WindowFnExprBuilder } from '@builders/relational/WindowFnExprBuilder.js' 
@@ -14,6 +14,7 @@ import { Table } from '../../semantic/Table.js'
 import { JoinSpec } from '@core/ast/JoinSpec.js'
 import { JoinBuilder } from '@builders/relational/JoinBuilder.js'
 import { ISemanticSelectBuilder } from '@core/interfaces/ISemanticSelectBuilder.js'
+import { SelectBuilder } from '@builders/relational/SelectBuilder.js'
 
 export type SemanticSelectionItem =
   | TypedColumn
@@ -27,13 +28,12 @@ export type WhereInput =
   | WhereClause
 
 export class SemanticSelectBuilder implements ISemanticSelectBuilder {
-  private whereInput?: WhereInput
-  private groupByColumns: ColumnRef[] = []
-  private orderByItems: OrderByItem[] = []
-  private limitValue?: number
-  private offsetValue?: number
-  private joinSpecs: JoinSpec[] = []
-
+  private whereInput?: WhereInput;
+  private groupByColumns: ColumnRef[] = [];
+  private orderByItems: OrderByItem[] = [];
+  private limitValue?: number;
+  private offsetValue?: number;
+  private joinSpecs: JoinSpec[] = [];
 
   constructor(
     private readonly table: Table,
@@ -42,75 +42,122 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
   ) {}
 
   where(input: WhereInput): this {
-    this.whereInput = input
-    return this
+    this.whereInput = input;
+    return this;
   }
 
   groupBy(...columns: TypedColumn[]): this {
-    this.groupByColumns = columns.map(col => col.ref)
-    return this
+    this.groupByColumns = columns.map((col) => col.ref);
+    return this;
   }
 
-  orderBy(column: TypedColumn, direction: 'ASC' | 'DESC' = 'ASC'): this {
-    this.orderByItems.push(new OrderByItem(column.ref, direction))
-    return this
+  orderBy(column: TypedColumn | AggExprBuilder, direction: "ASC" | "DESC" = "ASC"): this {
+    const expr = resolveOrderByExpr(column)
+    this.orderByItems.push(new OrderByItem(expr, direction));
+    return this;
   }
 
   limit(n: number): this {
-    this.limitValue = n
-    return this
+    this.limitValue = n;
+    return this;
   }
 
   offset(n: number): this {
-    this.offsetValue = n
-    return this
+    this.offsetValue = n;
+    return this;
   }
 
   private addJoin(spec: JoinSpec): this {
-  this.joinSpecs.push(spec)
-  return this
+    this.joinSpecs.push(spec);
+    return this;
   }
 
   join(table: Table): JoinBuilder<this> {
-  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'JOIN')
+    return new JoinBuilder(table, (spec) => this.addJoin(spec), "JOIN");
   }
 
   innerJoin(table: Table): JoinBuilder<this> {
-  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'INNER')
+    return new JoinBuilder(table, (spec) => this.addJoin(spec), "INNER");
   }
 
   leftJoin(table: Table): JoinBuilder<this> {
-  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'LEFT')
+    return new JoinBuilder(table, (spec) => this.addJoin(spec), "LEFT");
   }
 
   rightJoin(table: Table): JoinBuilder<this> {
-  return new JoinBuilder(table, (spec) => this.addJoin(spec), 'RIGHT')
+    return new JoinBuilder(table, (spec) => this.addJoin(spec), "RIGHT");
   }
 
   fullOuterJoin(table: Table): JoinBuilder<this> {
-  return new JoinBuilder(table,(spec) => this.addJoin(spec), 'FULL OUTER',)
+    return new JoinBuilder(table, (spec) => this.addJoin(spec), "FULL OUTER");
   }
 
-  private resolveSelections(): SelectQuery['select'] {
-    return this.selections.map(item => {
-      if (item instanceof AggExprBuilder)     return item.build()
-      if (item instanceof WindowFnExprBuilder) return item.build()
-      return item.ref
-    })
+  onde(input: WhereInput): this {
+    return this.where(input);
   }
 
-  private resolveWhere(): SelectQuery['where'] {
-    if (!this.whereInput) return undefined
+  agrupePor(...columns: TypedColumn[]): this {
+    return this.groupBy(...columns);
+  }
+
+  ordenePor(column: TypedColumn | AggExprBuilder, direction: "ASC" | "DESC" = "ASC"): this {
+    return this.orderBy(column, direction);
+  }
+
+  limite(n: number): this {
+    return this.limit(n);
+  }
+
+  deslocamento(n: number): this {
+    return this.offset(n);
+  }
+
+  // ─── Alias em português — JOINs ─────────────────────────────────────────
+  juncaoInterna(table: Table): JoinBuilder<this> {
+    return this.innerJoin(table);
+  }
+  
+  //equivalente ao join sozinho sem prefixo inner
+  junte(table: Table): JoinBuilder<this> {
+    return this.innerJoin(table);
+  }
+
+  juncaoEsquerda(table: Table): JoinBuilder<this> {
+    return this.leftJoin(table);
+  }
+
+  juncaoDireita(table: Table): JoinBuilder<this> {
+    return this.rightJoin(table);
+  }
+
+  juncaoExterna(table: Table): JoinBuilder<this> {
+    return this.fullOuterJoin(table);
+  }
+
+  private resolveSelections(): SelectQuery["select"] {
+    return this.selections.map((item) => {
+      if (item instanceof AggExprBuilder) return item.build();
+      if (item instanceof WindowFnExprBuilder) return item.build();
+      return item.ref;
+    });
+  }
+
+  buscar<T>(): Promise<T[]> {
+  return this.fetch<T>()
+  }
+
+  private resolveWhere(): SelectQuery["where"] {
+    if (!this.whereInput) return undefined;
 
     if (this.whereInput instanceof WhereClause) {
-      return this.whereInput
+      return this.whereInput;
     }
 
     if (Array.isArray(this.whereInput)) {
-      return new WhereClause(this.whereInput, 'AND')
+      return new WhereClause(this.whereInput, "AND");
     }
 
-    return new WhereClause([this.whereInput], 'AND')
+    return new WhereClause([this.whereInput], "AND");
   }
 
   build(): SelectQuery {
@@ -120,16 +167,16 @@ export class SemanticSelectBuilder implements ISemanticSelectBuilder {
       this.resolveWhere(),
       this.joinSpecs.length > 0 ? this.joinSpecs : undefined,
       this.groupByColumns.length > 0 ? this.groupByColumns : undefined,
-      this.orderByItems.length  > 0 ? this.orderByItems  : undefined,
+      this.orderByItems.length > 0 ? this.orderByItems : undefined,
       this.limitValue,
       this.offsetValue,
-    )
+    );
   }
 
   async fetch<T>(): Promise<T[]> {
-    const query = this.build()
-    const { sql, params } = SqlGenerator.compile(query)
-    const result = await this.adapter.execute(sql, params)
-    return result.rows
+    const query = this.build();
+    const { sql, params } = SqlGenerator.compile(query);
+    const result = await this.adapter.execute(sql, params);
+    return result.rows;
   }
 }

--- a/src/core/ast/OrderByItem.ts
+++ b/src/core/ast/OrderByItem.ts
@@ -11,3 +11,12 @@ export class OrderByItem {
     readonly direction: 'ASC' | 'DESC' = 'ASC'
   ) {}
 }
+
+export function resolveOrderByExpr(
+  column: { ref: ColumnRef } | { build: () => AggregateExpr },
+): OrderByExpr {
+  if ('build' in column && typeof column.build === 'function') {
+    return column.build()
+  }
+  return (column as { ref: ColumnRef }).ref
+}

--- a/src/core/ast/clause/WhereClause.ts
+++ b/src/core/ast/clause/WhereClause.ts
@@ -8,12 +8,6 @@ export class WhereClause {
 
 }
 
-
-//As soluções abaixo são provisórias e serão melhoradas com implementações com mais níveis de aninhamento em trabalahos futuros!
-/**
- * Helper para combinar condições com OR.
- * Exemplo: .where(or(vendas.vendedor_id.eq(1), vendas.vendedor_id.eq(2)))
- */
 export function or(...conditions: WhereCondition[]): WhereClause {
   if (conditions.length === 0) {
     throw new Error('or(): Pelo menos uma condição é necessária')
@@ -21,11 +15,6 @@ export function or(...conditions: WhereCondition[]): WhereClause {
   return new WhereClause(conditions, 'OR')
 }
 
-
-/**
- * Helper para combinar condições com AND.
- * Equivalente a passar um array direto no .where(), mas explícito.
- */
 export function and(...conditions: WhereCondition[]): WhereClause {
   if (conditions.length === 0) {
     throw new Error('and(): ao menos uma condição é necessária')

--- a/src/core/interfaces/ISelectBuilder.ts
+++ b/src/core/interfaces/ISelectBuilder.ts
@@ -12,4 +12,5 @@ export interface ISelectBuilder extends IBuilder<SelectQuery> {
   limit(n: number): this
   offset(n: number): this
   fetch<T extends Record<string, any> = any>(): Promise<T[]>;
+  selecione(fn: SelectFn): this
 }

--- a/src/core/interfaces/ISemanticSelectBuilder.ts
+++ b/src/core/interfaces/ISemanticSelectBuilder.ts
@@ -15,4 +15,15 @@ export interface ISemanticSelectBuilder {
   leftJoin(table: Table): JoinBuilder<this>
   rightJoin(table: Table): JoinBuilder<this>
   fullOuterJoin(table: Table): JoinBuilder<this> 
+  onde(input: unknown): this
+  agrupePor(...columns: unknown[]): this
+  ordenePor(column: unknown, direction?: 'ASC' | 'DESC'): this
+  limite(n: number): this
+  offset(n: number): this
+  juncaoInterna(table: Table): JoinBuilder<this>
+  junte(table: Table): JoinBuilder<this>
+  juncaoEsquerda(table: Table): JoinBuilder<this>
+  juncaoDireita(table: Table): JoinBuilder<this>
+  juncaoExterna(table: Table): JoinBuilder<this> 
+  buscar()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { WindowFnExprBuilder } from './builders/relational/WindowFnExprBuilder.j
 import { ColumnRef } from '@core/ColumnRef.js'; 
 import { AggExprBuilder } from '@builders/relational/AggExprBuilder.js';
 import { TypedColumn } from './semantic/TypedColumn.js';
+import { or, and } from '@core/ast/clause/WhereClause.js';
 
 export const lag = (col: string | AggExprBuilder, offset = 1) => {
     const columnExpr = col instanceof AggExprBuilder
@@ -44,3 +45,14 @@ export { PgAdapter }from './infrastructure/adapters/PgAdapter.js'
 export type { IQueryExecutor } from './core/interfaces/IQueryExecutor.js'
 export type { IQueryResult }   from './core/interfaces/IQueryExecutor.js'
 export type { IRawQueryCheck } from './core/interfaces/IRawQueryCheck.js'
+
+// ─── Aliases em português — Window Functions ──────────────────────────────
+export const classificar = rank
+export const classificarDenso = denseRank
+export const numeroDaLinha = rowNumber
+export const anterior = lag
+export const proximo = lead
+//export const grupo = ntile
+export const media = avg
+export const ou = or
+export const e = and

--- a/src/semantic/Table.ts
+++ b/src/semantic/Table.ts
@@ -43,6 +43,12 @@ export class Table {
     }
     return this._builderFactory(this, items)
   }
+
+  selecione(items: SemanticSelectionItem[]) {
+    return this.select(items)
+  }  
+  
+
 }
   
 export function createTable(

--- a/src/semantic/TypedColumn.ts
+++ b/src/semantic/TypedColumn.ts
@@ -12,41 +12,109 @@ import { WhereCondition } from '../core/ast/clause/WhereCondition.js'
  * Em vez de: c.col('seller_name', 'o')
  * Você usa:  orders.seller_name
  */
+
 export class TypedColumn<T extends SqlType = SqlType> {
-  readonly ref: ColumnRef<T>
+  readonly ref: ColumnRef<T>;
 
   constructor(
     readonly name: string,
     readonly type: T,
     readonly table?: string,
   ) {
-    this.ref = new ColumnRef(name, type, table)
+    this.ref = new ColumnRef(name, type, table);
   }
 
-  // Alias visual — não muda o SQL, só documenta a intenção
   as(alias: string): AliasedColumn<T> {
-    return new AliasedColumn(this.name, this.type, alias, this.table)
+    return new AliasedColumn(this.name, this.type, alias, this.table);
   }
 
-  // Agregações — disponíveis diretamente na coluna
-  sum(): AggExprBuilder  { return new AggExprBuilder('SUM', this.ref) }
-  avg(): AggExprBuilder  { return new AggExprBuilder('AVG', this.ref) }
-  count(): AggExprBuilder { return new AggExprBuilder('COUNT', this.ref) }
-  min(): AggExprBuilder  { return new AggExprBuilder('MIN', this.ref) }
-  max(): AggExprBuilder  { return new AggExprBuilder('MAX', this.ref) }
+  sum(): AggExprBuilder {
+    return new AggExprBuilder("SUM", this.ref);
+  }
+  avg(): AggExprBuilder {
+    return new AggExprBuilder("AVG", this.ref);
+  }
+  count(): AggExprBuilder {
+    return new AggExprBuilder("COUNT", this.ref);
+  }
+  min(): AggExprBuilder {
+    return new AggExprBuilder("MIN", this.ref);
+  }
+  max(): AggExprBuilder {
+    return new AggExprBuilder("MAX", this.ref);
+  }
 
-  // Condições WHERE — direto na coluna
-  eq(value: unknown): WhereCondition    { return new WhereCondition(this.ref, '=', value) }
-  neq(value: unknown): WhereCondition   { return new WhereCondition(this.ref, '!=', value) }
-  gt(value: unknown): WhereCondition    { return new WhereCondition(this.ref, '>', value) }
-  lt(value: unknown): WhereCondition    { return new WhereCondition(this.ref, '<', value) }
-  gte(value: unknown): WhereCondition   { return new WhereCondition(this.ref, '>=', value) }
-  lte(value: unknown): WhereCondition   { return new WhereCondition(this.ref, '<=', value) }
+  eq(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, "=", value);
+  }
+  neq(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, "!=", value);
+  }
+  gt(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, ">", value);
+  }
+  lt(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, "<", value);
+  }
+  gte(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, ">=", value);
+  }
+  lte(value: unknown): WhereCondition {
+    return new WhereCondition(this.ref, "<=", value);
+  }
   between(a: unknown, b: unknown): WhereCondition {
-    return new WhereCondition(this.ref, 'BETWEEN', [a, b])
+    return new WhereCondition(this.ref, "BETWEEN", [a, b]);
   }
   in(values: unknown[]): WhereCondition {
-    return new WhereCondition(this.ref, 'IN', values)
+    return new WhereCondition(this.ref, "IN", values);
+  }
+
+  // ─── Alias em português — Agregações ────────────────────────────────────
+  soma(): AggExprBuilder {
+    return this.sum();
+  }
+  media(): AggExprBuilder {
+    return this.avg();
+  }
+  contar(): AggExprBuilder {
+    return this.count();
+  }
+  minimo(): AggExprBuilder {
+    return this.min();
+  }
+  maximo(): AggExprBuilder {
+    return this.max();
+  }
+
+  // --- Condições WHERE ───────────────────────────────
+  igual(value: unknown): WhereCondition {
+    return this.eq(value);
+  }
+  diferente(value: unknown): WhereCondition {
+    return this.neq(value);
+  }
+  maiorQue(value: unknown): WhereCondition {
+    return this.gt(value);
+  }
+  menorQue(value: unknown): WhereCondition {
+    return this.lt(value);
+  }
+  maiorOuIgual(value: unknown): WhereCondition {
+    return this.gte(value);
+  }
+  menorOuIgual(value: unknown): WhereCondition {
+    return this.lte(value);
+  }
+  entre(a: unknown, b: unknown): WhereCondition {
+    return this.between(a, b);
+  }
+  dentroDe(values: unknown[]): WhereCondition {
+    return this.in(values);
+  }
+
+  //Alias de coluna
+  como(alias: string): AliasedColumn {
+    return this.as(alias);
   }
 }
 

--- a/src/test/integration/semantic/FullOuterJoin.test.ts
+++ b/src/test/integration/semantic/FullOuterJoin.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
-import type { TypedColumn } from '@semantic/TypedColumn.js'
 import 'dotenv/config'
 
 const CONNECTION_STRING = process.env.DB_STRING_CONNECTION

--- a/src/test/integration/semantic/PortuguesImplementation.test.ts
+++ b/src/test/integration/semantic/PortuguesImplementation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import 'dotenv/config'
+import { ou, classificar } from '../../../index.js'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+describe('SemanticSelecBuilder — integração com PostgreSQL e ordenação atendida também via AggregateExpr', () => {
+  let ctx: AnalyticsContext 
+  let vendas: Awaited<ReturnType<AnalyticsContext['table']>>
+
+  beforeAll(async () => {
+    ctx = new AnalyticsContext(CONNECTION_STRING)
+    vendas = await ctx.table('vendas')
+  })
+
+  afterAll(async () => {
+    await (ctx as any).adapter.close()
+  })
+
+  it('deve construir a query de classificação corretamente', async () => {
+
+   await vendas
+    .selecione([
+      vendas.vendedor_id,
+      vendas.mes,
+      vendas.total.soma().as("total_vendas"),
+      classificar()
+        .sobre((w) => 
+          w.particionePor("mes").ordenePor(vendas.total.soma(), "DESC"),
+        )
+        .as("classificacao"),
+    ])
+    .onde(ou(vendas.vendedor_id.igual(1), vendas.vendedor_id.igual(2)))
+    .agrupePor(vendas.vendedor_id, vendas.mes)
+    .ordenePor(vendas.mes)
+    .limite(10)
+    .build();
+  })
+})

--- a/src/test/integration/semantic/SemanticSelectBuilderIntegration.test.ts
+++ b/src/test/integration/semantic/SemanticSelectBuilderIntegration.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { AnalyticsContext } from '@semantic/AnalyticsContext.js'
+import 'dotenv/config'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+describe('SemanticSelecBuilder — integração com PostgreSQL e ordenação atendida também via AggregateExpr', () => {
+  let ctx: AnalyticsContext 
+  let vendas: Awaited<ReturnType<AnalyticsContext['table']>>
+
+  beforeAll(async () => {
+    ctx = new AnalyticsContext(CONNECTION_STRING)
+    vendas = await ctx.table('vendas')
+  })
+
+  afterAll(async () => {
+    await (ctx as any).adapter.close()
+  })
+
+  it('ordena pelo total agregado (ORDER BY no nível externo da query)', async () => {
+  const result = await vendas
+    .select([vendas.vendedor_id, vendas.total.sum().as('total_vendas')])
+    .groupBy(vendas.vendedor_id)
+    .orderBy(vendas.total.sum(), 'DESC')
+    .fetch<{ vendedor_id: number; total_vendas: string }>()
+
+  expect(result.length).toBeGreaterThan(0)
+  const valores = result.map(r => Number(r.total_vendas))
+  const ordenado = [...valores].sort((a, b) => b - a)
+  expect(valores).toEqual(ordenado)
+})
+
+})

--- a/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
+++ b/src/test/src/builders/semantic/SemanticSelectBuilder.test.ts
@@ -112,4 +112,6 @@ describe('SemanticSelectBuilder', () => {
     )
   })
 
+  
+
 })

--- a/src/usecases/exemploModoPortugues.ts
+++ b/src/usecases/exemploModoPortugues.ts
@@ -1,0 +1,164 @@
+import { AnalyticsContext } from '../semantic/AnalyticsContext.js'
+import { classificar, anterior, ou, e } from '../index.js'
+import 'dotenv/config'
+
+const CONNECTION_STRING = process.env.DB_STRING_CONNECTION
+
+const linha  = (char = '─', n = 60) => char.repeat(n)
+const titulo = (texto: string) => {
+  console.log('\n' + linha('═'))
+  console.log(`  ${texto}`)
+  console.log(linha('═'))
+}
+
+async function main() {
+  const ctx    = new AnalyticsContext(CONNECTION_STRING)
+  const vendas = await ctx.table('vendas')
+
+  titulo('Beiju — Exemplo de uso em português')
+  console.log('  Mesma engine, vocabulário localizado.\n')
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 1 — Consulta simples com filtro e ordenação
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[1] Consulta simples — selecione / onde / ordenePor')
+
+  const exemplo1 = await vendas
+    .selecione([
+      vendas.vendedor_id,
+      vendas.mes,
+      vendas.total,
+    ])
+    .where(vendas.total.gt(500))
+    .orderBy(vendas.total, 'DESC')
+    .limit(5)
+    .fetch()
+
+  console.table(exemplo1)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 2 — Agregação com alias e agrupamento
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[2] Agregação — soma / como / agrupePor')
+
+  const exemplo2 = await vendas
+    .selecione([
+      vendas.vendedor_id,
+      vendas.total.soma().como('total_vendido'),
+    ])
+    .agrupePor(vendas.vendedor_id)
+    .ordenePor(vendas.total.soma(), 'DESC')
+    .buscar()
+
+  console.table(exemplo2)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 3 — Window Function: ranking por mês
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[3] Função de janela — classificar / sobre / particionePor')
+
+  const exemplo3 = await vendas
+    .selecione([
+      vendas.vendedor_id,
+      vendas.mes,
+      vendas.total.soma().como('total_vendas'),
+      classificar()
+        .sobre(w => w
+          .particionePor('mes')
+          .ordenePor(vendas.total.soma(), 'DESC'))
+        .como('classificacao'),
+    ])
+    .agrupePor(vendas.vendedor_id, vendas.mes)
+    .ordenePor(vendas.mes)
+    .buscar()
+
+  console.table(exemplo3)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 4 — Comparação com mês anterior (LAG)
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[4] Comparação temporal — anterior() (alias de lag)')
+
+  const exemplo4 = await vendas
+    .selecione([
+      vendas.vendedor_id,
+      vendas.mes,
+      vendas.total.soma().como('total_vendas'),
+      anterior(vendas.total.soma(), 1)
+        .sobre(w => w
+          .particionePor('vendedor_id')
+          .ordenePor('mes'))
+        .como('total_mes_anterior'),
+    ])
+    .agrupePor(vendas.vendedor_id, vendas.mes)
+    .ordenePor(vendas.vendedor_id)
+    .buscar()
+
+  console.table(exemplo4)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 5 — Condição composta com ou()
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[5] Condição composta — ou() filtrando múltiplos vendedores')
+
+  const exemplo5 = await vendas
+    .selecione([vendas.vendedor_id, vendas.mes, vendas.total])
+    .onde(ou(
+      vendas.vendedor_id.igual(1),
+      vendas.vendedor_id.igual(2),
+    ))
+    .buscar()
+
+  console.table(exemplo5)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 6 — Condição composta com e()
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[6] Condição composta — e() combinando filtros')
+
+  const exemplo6 = await vendas
+    .selecione([vendas.vendedor_id, vendas.mes, vendas.total])
+    .onde(e(
+      vendas.vendedor_id.igual(1),
+      vendas.total.maiorQue(500),
+    ))
+    .buscar()
+
+  console.table(exemplo6)
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXEMPLO 7 — Junção entre tabelas (vendas + vendedores)
+  // ══════════════════════════════════════════════════════════════════════
+
+  titulo('[7] Junção — juncaoInterna / em / como')
+
+  const vendedores = await ctx.table('vendedores')
+
+  const exemplo7 = await vendas
+    .selecione([
+      vendedores.nome.como('nome_vendedor'),
+      vendas.mes,
+      vendas.total.soma().como('total_vendas'),
+    ])
+    .juncaoInterna(vendedores).em(vendas.vendedor_id, vendedores.id)
+    .agrupePor(vendedores.nome, vendas.mes)
+    .ordenePor(vendas.mes)
+    .buscar()
+
+  console.table(exemplo7)
+
+  // ══════════════════════════════════════════════════════════════════════
+
+  await (ctx as any).adapter.close()
+  console.log('\n' + linha('─'))
+  console.log('  Conexão encerrada.')
+  console.log(linha('─') + '\n')
+}
+
+main().catch(console.error)


### PR DESCRIPTION
## O que este PR faz

Adiciona uma camada de aliases em português sobre a API existente do
Beiju, permitindo escrever consultas analíticas inteiramente em
português — sem perda de autocomplete ou type-safety.

```typescript
await vendas
  .selecione([
    vendas.vendedor_id,
    vendas.total.soma().como('total_vendas'),
    classificar()
      .sobre(w => w.particionePor('mes').ordenePor(vendas.total.soma(), 'DESC'))
      .como('classificacao'),
  ])
  .onde(ou(vendas.vendedor_id.igual(1), vendas.vendedor_id.igual(2)))
  .agrupePor(vendas.vendedor_id, vendas.mes)
  .buscar()
```

## Por que

Conecta diretamente com a justificativa central do projeto: tornar
consultas analíticas acessíveis a desenvolvedores júnior e
stakeholders sem domínio profundo de SQL. Mesma lógica de produtos
como o Excel, que localiza nomes de fórmulas (`SUM` → `SOMA`,
`PROCV` → `VLOOKUP`) para reduzir a barreira de entrada.

## Como foi feito

Cada alias é um **método real** da classe correspondente, que
delega para a implementação em inglês já testada:

```typescript
soma(): AggExprBuilder { return this.sum() }
```

Decisão deliberada: nada de Proxy dinâmico de tradução ou estado de
idioma em runtime. Isso preserva 100% do autocomplete e da inferência
de tipos do TypeScript nos dois vocabulários, com custo de
implementação mínimo e zero risco de regressão na API em inglês.

## Bug encontrado e corrigido no processo

`orderBy()` no nível externo da query (fora do `.over()`) não aceitava
`AggExprBuilder`, apenas `TypedColumn`/`string`. Isso impedia ordenar
o resultado final por uma coluna agregada (`ORDER BY SUM(total) DESC`),
embora o mesmo já funcionasse dentro de `WindowBuilder.orderBy()`.
Extraído um helper `resolveOrderByExpr()` compartilhado entre os dois
builders para eliminar a duplicação e fechar a paridade.

## Testes

- [x] Teste de integração contra PostgreSQL real validando ORDER BY
      sobre AggregateExpr
- [x] Use case completo (`exemploModoPortugues.ts`) cobrindo os 7
      cenários centrais do Beiju em português: filtro simples,
      agregação, Window Function (RANK), comparação temporal (LAG),
      condições compostas (OR/AND) e JOIN
- [x] Suíte completa (`npx vitest run`) sem regressões

## Escopo explicitamente fora deste PR

Seleção dinâmica de idioma (`LanguageType.PT/EN` configurável via
`AnalyticsContext`) foi avaliada e documentada como trabalho futuro.
Exigiria remapeamento de tipos via mapped types (`as` clause) ou
geração de classes espelho — ambos representam uma frente de
engenharia de tipos independente, fora do escopo de tempo do MVP
atual.